### PR TITLE
Update openforms_form.html

### DIFF
--- a/openformsclient/templates/openformsclient/templatetags/openforms_form.html
+++ b/openformsclient/templates/openformsclient/templatetags/openforms_form.html
@@ -2,6 +2,7 @@
     id="{{ html_id }}"
     data-base-url="{{ base_url }}"
     data-form-id="{{ form_id }}"
+    class="openforms-theme"
     {% if base_path %}data-base-path="{{ base_path }}"{% endif %}
     {% if csp_nonce %}data-csp-nonce="{{ csp_nonce }}"{% endif %}
     {% if lang %}data-lang="{{ lang }}"{% endif %}


### PR DESCRIPTION
Besproken met @LaurensBurger , deze additionele class op de embed is nodig omdat sinds OF 2.1 er anders stijlloze formulieren worden geembed (OIP Taiga #1572, ook ondervonden door ODRU).

Tevens vinden Laurens en ik dat de ingestelde OF stijl eigenlijk automatisch mee zou moeten komen in de snippet/plugin/embed, dat is van wat wij zien momenteel niet het geval.