### PR TITLE
[#8] Update API endpoint for forms

### DIFF
--- a/openformsclient/client.py
+++ b/openformsclient/client.py
@@ -35,14 +35,14 @@ class Client:
         try:
             # We do a head request to actually hit a protected endpoint without
             # getting a whole bunch of data.
-            response = self._request("head", "forms")
+            response = self._request("head", "public/forms")
             response.raise_for_status()
             return (True, "")
         except HTTPError as e:
             # If something is wrong, we might get more information from the
             # error message provided by Open Forms.
             try:
-                response = self._request("get", "forms")
+                response = self._request("get", "public/forms")
                 data = response.json()
                 message = (
                     data.get("detail", data.get("title"))
@@ -62,7 +62,7 @@ class Client:
 
         :returns: The API response content as Python object.
         """
-        response = self._request("get", "forms")
+        response = self._request("get", "public/forms")
         response.raise_for_status()
 
         return response.json()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,7 +21,7 @@ class IntegrationTests(TestCase):
 
     def _prepare_mock(self, m):
         m.get(
-            f"{self.config.api_root}forms",
+            f"{self.config.api_root}public/forms",
             json=[
                 {
                     "uuid": "1b0d0675-2caf-48e8-beda-c32c6732b63c",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,7 +22,7 @@ class UtilsTests(TestCase):
 
     def test_get_form_choices_without_client(self, m):
         m.get(
-            f"{self.config.api_root}forms",
+            f"{self.config.api_root}public/forms",
             json=[
                 {
                     "uuid": "1b0d0675-2caf-48e8-beda-c32c6732b63c",
@@ -49,7 +49,7 @@ class UtilsTests(TestCase):
 
     def test_get_form_choices_with_client(self, m):
         m.get(
-            f"{self.config.api_root}forms",
+            f"{self.config.api_root}public/forms",
             json=[
                 {
                     "uuid": "1b0d0675-2caf-48e8-beda-c32c6732b63c",
@@ -76,7 +76,7 @@ class UtilsTests(TestCase):
 
     def test_get_form_choices_use_uuids(self, m):
         m.get(
-            f"{self.config.api_root}forms",
+            f"{self.config.api_root}public/forms",
             json=[
                 {
                     "uuid": "1b0d0675-2caf-48e8-beda-c32c6732b63c",


### PR DESCRIPTION
Fixes #8 

We only support OpenForms >= 2.6, where the new endpoint was introduced (the only supported version that does not have the new endpoint is 2.5).