### PR TITLE
Replace mocks with VCR casettes for client testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.9', '3.10', '3.11']
-        django: ['3.2', '4.0']
+        python: ['3.11', '3.12']
+        django: ['4.2']
     name: Run the test suite (Python ${{ matrix.python }}, Django ${{ matrix.django }})
 
     steps:
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.11'
 
       - name: Build sdist and wheel
         run: |

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ Open Forms Client (for Django)
 :Version: 0.4.0
 :Source: https://github.com/open-formulieren/open-forms-client-django
 :Keywords: Open Forms, Client, Django
-:PythonVersion: 3.9 - 3.11
-:DjangoVersion: 3.2 - 4.0
+:PythonVersion: 3.11+
+:DjangoVersion: 4.2
 
 |build-status| |code-quality| |black| |coverage|
 
@@ -37,8 +37,8 @@ Installation
 Requirements
 ------------
 
-* Python 3.9 or newer
-* Django 3.2 or newer
+* Python 3.11 or newer
+* Django 4.2
 
 
 Install

--- a/fixtures/cassettes/forms.yaml
+++ b/fixtures/cassettes/forms.yaml
@@ -1,0 +1,671 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: HEAD
+    uri: https://open-forms.test.maykin.opengem.nl/api/v2/public/forms
+  response:
+    body:
+      string: ''
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - max-age=0, no-cache, no-store, must-revalidate, private
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Language:
+      - nl
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Wed, 31 Jul 2024 09:12:34 GMT
+      Expires:
+      - Wed, 31 Jul 2024 09:12:34 GMT
+      Permissions-Policy:
+      - accelerometer=(), autoplay=(), camera=(self), gyroscope=(), geolocation=(self),
+        magnetometer=(), microphone=()
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - same-origin
+      - same-origin
+      Set-Cookie:
+      - csrftoken=dnVGEBFejffOwbLLGCIyyl0HoqKtRlSh; expires=Wed, 30 Jul 2025 09:12:34
+        GMT; Max-Age=31449600; Path=/; SameSite=None; Secure
+      - openforms_sessionid=sh8sq621ge72pgec694ab0kb629bh7q0; expires=Wed, 31 Jul
+        2024 09:17:34 GMT; HttpOnly; Max-Age=300; Path=/; SameSite=None; Secure
+      Strict-Transport-Security:
+      - max-age=63072000
+      Vary:
+      - Accept-Encoding
+      - Cookie, Origin, Accept-Language
+      X-CSRFToken:
+      - 8i8o2vbaoFxknV1lkcgU3yOfg9U3m6h4bvTUwWGexKCYJWCWQEOirJEMupum3hZb
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Is-Form-Designer:
+      - 'true'
+      X-Session-Expires-In:
+      - '300'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://open-forms.test.maykin.opengem.nl/api/v2/public/forms
+  response:
+    body:
+      string: "{\"results\":[{\"uuid\":\"9c65ab49-2635-4c8d-ac22-aaca67044a6c\",\"name\":\"Open
+        Inwoner ZGW Dev\",\"internalName\":\"\",\"slug\":\"open-inwoner-zgw-dev\"},{\"uuid\":\"cdf10c6c-93c2-4ddd-822f-84158f8c1569\",\"name\":\"Test
+        logic with repeating groups\",\"internalName\":\"\",\"slug\":\"test-logic-with-repeating-groups\"},{\"uuid\":\"0ba77cff-eff9-4d90-9c46-fa0c5ab8227c\",\"name\":\"Maykin
+        Test - All Fields\",\"internalName\":\"\",\"slug\":\"maykin-test-all-fields\"},{\"uuid\":\"a8790afe-d596-4aa4-9a2a-5589eaa24fa1\",\"name\":\"Test
+        mede ondertekenen (kopie)\",\"internalName\":\"\",\"slug\":\"test-mede-ondertekenen-kopie\"},{\"uuid\":\"f54f4904-ad28-4945-9763-293112ff2864\",\"name\":\"testdropdownmobile\",\"internalName\":\"\",\"slug\":\"testdropdownmobile\"},{\"uuid\":\"72c63d47-0e45-46b5-bbff-7be60b371ea5\",\"name\":\"Test
+        email confirmation\",\"internalName\":\"\",\"slug\":\"test-email-confirmation\"},{\"uuid\":\"aa69acef-4c5b-4bf7-b62e-bd379a34c7f2\",\"name\":\"XSS
+        ALL THE THINGS\",\"internalName\":\"\",\"slug\":\"xss-all-the-things\"},{\"uuid\":\"a637d1f6-3650-4e10-a5fb-6719b282570a\",\"name\":\"demoform-energietoeslag\",\"internalName\":\"\",\"slug\":\"demoform-energietoeslag\"},{\"uuid\":\"ff19a19c-54c8-4c2f-bb37-3631ac77922e\",\"name\":\"Taiga
+        428 DH - Checkbox label in summary\",\"internalName\":\"\",\"slug\":\"taiga-428-dh-checkbox-label-in-summary\"},{\"uuid\":\"5dc6f0e8-7628-4c7b-aff6-e4c9c1f92491\",\"name\":\"breakingthelogictab\",\"internalName\":\"\",\"slug\":\"breakingthelogictab\"},{\"uuid\":\"c458c8a1-880c-4a03-bd2f-3bbc68370eb4\",\"name\":\"DH
+        Taiga 441 - Content components\",\"internalName\":\"\",\"slug\":\"dh-taiga-441-content-components\"},{\"uuid\":\"75c3095f-dcf4-4b97-93b4-5e3a649d46f9\",\"name\":\"2771\",\"internalName\":\"\",\"slug\":\"2771\"},{\"uuid\":\"89c01672-203b-410b-9cbe-5885bb4d95bf\",\"name\":\"Aanvraag
+        subsidieregeling voor amateurkunst\",\"internalName\":\"\",\"slug\":\"aanvraagformulier-subsidieregeling-voor-amateurkunst\"},{\"uuid\":\"6c78e2cc-d46e-492a-97c2-a069c1bfb6bb\",\"name\":\"Noodhulpetestutrecht\",\"internalName\":\"\",\"slug\":\"noodhulp-dd5aed\"},{\"uuid\":\"cc67bd60-c9e5-430c-9311-d1abdaaca902\",\"name\":\"2.4
+        release test (Sergei)\",\"internalName\":\"\",\"slug\":\"24-release-test-sergei\"},{\"uuid\":\"ec08930e-5318-4f07-aeee-e59f74f12c5e\",\"name\":\"tellen\",\"internalName\":\"\",\"slug\":\"tellen\"},{\"uuid\":\"8060e5d9-d1a0-40c8-993f-24290fb84336\",\"name\":\"2689\",\"internalName\":\"\",\"slug\":\"2689\"},{\"uuid\":\"372ae814-d9f5-4f50-a524-53b1d68efe42\",\"name\":\"repeatinggroupupload\",\"internalName\":\"\",\"slug\":\"repeatinggroupupload\"},{\"uuid\":\"cf22f942-ea84-45ee-8c50-629a5813d167\",\"name\":\"Wijziging
+        leerlingenvervoer doorgeven\",\"internalName\":\"\",\"slug\":\"wijziging-leerlingenvervoer-doorgeven\"},{\"uuid\":\"8aeb781f-56d7-4e58-b268-0f5af4624ab5\",\"name\":\"Self
+        XSS\",\"internalName\":\"\",\"slug\":\"self-xss\"},{\"uuid\":\"82016848-12a7-4d95-8888-f6d604e985a8\",\"name\":\"Maykin
+        Test - Appointment plugin: JCC (Horst a/d Maas)\",\"internalName\":\"\",\"slug\":\"test-afspraken-82a7de\"},{\"uuid\":\"a7b45234-cd93-45e6-bb97-b5bd9c0207df\",\"name\":\"Bart
+        Test - Appointment plugin: JCC (Horst a/d Maas) (qr-email)\",\"internalName\":\"\",\"slug\":\"test-afspraken-bart\"},{\"uuid\":\"10d56df0-19e3-46f3-aa9c-6bcc25765f16\",\"name\":\"Taiga
+        DH 464 - bug repeating groups\",\"internalName\":\"\",\"slug\":\"taiga-dh-464-bug-repeating-groups\"},{\"uuid\":\"fd1a594a-b90b-4545-aefe-5564c8bd0a26\",\"name\":\"testranslatuionfromen\",\"internalName\":\"\",\"slug\":\"testranslatuionfromen\"},{\"uuid\":\"069104b0-8fd3-483d-a794-a0137d846a1b\",\"name\":\"Evenement
+        melden maykin test\",\"internalName\":\"\",\"slug\":\"evenement-melden-0eaad4\"},{\"uuid\":\"ef840f64-de84-49f9-8909-95092c0acf04\",\"name\":\"Aanmelden
+        bijeenkomst\",\"internalName\":\"Aanmelden bijeenkomst standaard [Mail]\",\"slug\":\"aanmelden-bijeenkomst\"},{\"uuid\":\"f9a2f939-dc66-4b27-9740-74836b9b9b35\",\"name\":\"\",\"internalName\":\"Aanmelden
+        bijeenkomst standaard [Mail]\",\"slug\":\"aanmelden-bijeenkomst-ca3d4a\"},{\"uuid\":\"211be881-ba0f-4334-a740-c48c816493a6\",\"name\":\"Aanmelden
+        bijeenkomst\",\"internalName\":\"Aanmelden bijeenkomst standaard [Mail]\",\"slug\":\"aanmelden-bijeenkomst-2cc677\"},{\"uuid\":\"74101277-19ab-45ac-93d4-bd49a8456517\",\"name\":\"Backoffice\",\"internalName\":\"\",\"slug\":\"backoffice\"},{\"uuid\":\"a02a1e77-dd48-45d6-a61d-e5310bb87226\",\"name\":\"afspraken
+        test\",\"internalName\":\"\",\"slug\":\"afspraken-test\"},{\"uuid\":\"8cafa022-380e-4af8-a0fc-2865b2f1603f\",\"name\":\"Zonder
+        interne naam\",\"internalName\":\"\",\"slug\":\"reiskosten-terugvragen-d1de57-kopie\"},{\"uuid\":\"dad1460c-562c-40ed-9df2-755a38469b9f\",\"name\":\"Gen0x4\",\"internalName\":\"\",\"slug\":\"gen0x4\"},{\"uuid\":\"cd3475ed-37ba-4658-b14b-d865cd1f3e82\",\"name\":\"Test
+        date default value\",\"internalName\":\"\",\"slug\":\"test-date-default-value\"},{\"uuid\":\"d38601f2-68e6-4f6c-9f8d-b63f2743eac9\",\"name\":\"Bbz
+        aanvraag\",\"internalName\":\"\",\"slug\":\"bbz-aanvraag\"},{\"uuid\":\"ccab1557-c25e-4f05-83b6-b6078a8882cf\",\"name\":\"Test
+        - Display login buttons\",\"internalName\":\"\",\"slug\":\"test-display-login-buttons\"},{\"uuid\":\"8fc1ffd8-e391-43b3-909b-12e08189b6b2\",\"name\":\"Afspraak
+        demo\",\"internalName\":\"\",\"slug\":\"afspraak-demo\"},{\"uuid\":\"212591fe-f894-44fc-9545-5200a550c87d\",\"name\":\"2305
+        - formstep delete\",\"internalName\":\"\",\"slug\":\"2305-formstep-delete\"},{\"uuid\":\"fb41df82-b0db-4c19-a0fd-ce084bd2f785\",\"name\":\"Test
+        - Display login options\",\"internalName\":\"\",\"slug\":\"test-display-login-options\"},{\"uuid\":\"61ead15f-4827-42d7-aa11-c8a7b82e5a92\",\"name\":\"Test
+        nested fields\",\"internalName\":\"\",\"slug\":\"test-nested-fields\"},{\"uuid\":\"c7d89e90-8b42-426d-9a8f-b1ac35cb96b6\",\"name\":\"Test
+        appointments PI\",\"internalName\":\"\",\"slug\":\"test-appointments-pi\"},{\"uuid\":\"084ad1f0-1712-4b8b-811e-ba4702e45073\",\"name\":\"Beslisboom
+        demo\",\"internalName\":\"\",\"slug\":\"beslisboom\"},{\"uuid\":\"d2cd30c9-13ec-47d6-9b21-47baf18a705c\",\"name\":\"Test
+        - HTML in components\",\"internalName\":\"\",\"slug\":\"test-html-in-components\"},{\"uuid\":\"3de62d35-60af-488e-bd30-13c1a2a85ef6\",\"name\":\"venrtest34\",\"internalName\":\"\",\"slug\":\"venrtest341\"},{\"uuid\":\"3c98d29f-b028-4737-abb7-f367b3bc57d2\",\"name\":\"testzds\",\"internalName\":\"\",\"slug\":\"testzds\"},{\"uuid\":\"4e396500-f4b7-4e77-aeb8-eb6757bd5997\",\"name\":\"Sprint
+        12 demo\",\"internalName\":\"\",\"slug\":\"sprint-12-demo\"},{\"uuid\":\"a5c464a5-7e7f-4628-8113-b38acb76cb60\",\"name\":\"Sprint
+        15 demo\",\"internalName\":\"\",\"slug\":\"sprint-15-demo\"},{\"uuid\":\"83251639-4f46-4c50-9037-f20fc5bb1457\",\"name\":\"3594
+        - optional map\",\"internalName\":\"\",\"slug\":\"3594-optional-map\"},{\"uuid\":\"a43def98-13d5-45f9-80ef-47699fb825c7\",\"name\":\"test
+        radio en selectie tooltips\",\"internalName\":\"\",\"slug\":\"test\"},{\"uuid\":\"72c5cc2e-68c3-4788-9309-dcd4912afd43\",\"name\":\"quarter
+        today and birthday\",\"internalName\":\"\",\"slug\":\"quartertodayandbirthday-feb756\"},{\"uuid\":\"7799f6ec-9cd2-45e4-82d5-61669680d55b\",\"name\":\"MER
+        beoordeling aanvragen\",\"internalName\":\"\",\"slug\":\"mer-beoordeling-aanvragen\"},{\"uuid\":\"38f1d53d-d222-4f41-b61e-8ea41aabbe8d\",\"name\":\"inzending
+        emailtest\",\"internalName\":\"\",\"slug\":\"inzending-emailtest\"},{\"uuid\":\"fbf1b453-8fa8-4331-9b48-bb44f4c09642\",\"name\":\"Test
+        Taiga issue 457 - jumping focus\",\"internalName\":\"\",\"slug\":\"test-taiga-issue-457-jumping-focus\"},{\"uuid\":\"57203b74-6f83-4cb0-b666-7a6d6b74de3c\",\"name\":\"venr
+        stufissue\",\"internalName\":\"\",\"slug\":\"venr-stufissue\"},{\"uuid\":\"87ce1df9-3bc5-467f-8352-4c07bf61ca57\",\"name\":\"Issue
+        Laurens Eigenschapsnaam\",\"internalName\":\"\",\"slug\":\"issue-laurens-eigenschapsnaam\"},{\"uuid\":\"9d6d599f-008c-4a9b-88db-1055e90933b5\",\"name\":\"Issue
+        HEIC files\",\"internalName\":\"\",\"slug\":\"issue-heic-files\"},{\"uuid\":\"13605410-12a8-4052-9b9d-0c7ba4960079\",\"name\":\"testzoveel\",\"internalName\":\"\",\"slug\":\"testzoveel\"},{\"uuid\":\"0079c170-3550-4d44-aa98-bcfcaed9a858\",\"name\":\"Issue
+        JSON logic rule\",\"internalName\":\"\",\"slug\":\"issue-json-logic-rule\"},{\"uuid\":\"a997497d-d690-406a-aeaa-3807342c4899\",\"name\":\"GH
+        2716: co-sign-information\",\"internalName\":\"\",\"slug\":\"gh-2716-co-sign-information\"},{\"uuid\":\"19e4ee21-56cd-4394-98ba-4ebd116403bc\",\"name\":\"Issue
+        2939 - Co-sign investigation\",\"internalName\":\"\",\"slug\":\"issue-2935-co-sign-investigation\"},{\"uuid\":\"166c8a3c-8fe7-44c8-bab5-4a8642eb2385\",\"name\":\"Aanvraagformulier
+        Ooievaarspas 1\",\"internalName\":\"\",\"slug\":\"aanvraagformulier-ooievaarspas-1\"},{\"uuid\":\"d3fc92c8-234d-4d55-8f9c-937b9f800d03\",\"name\":\"Rijbewijs
+        aanvraag demo\",\"internalName\":\"\",\"slug\":\"rijbewijs-aanvraag-demo\"},{\"uuid\":\"e7e8b109-92a3-4545-827e-ff5781c1a6e2\",\"name\":\"Test
+        Hedda 22 nov\",\"internalName\":\"\",\"slug\":\"test-hedda-22-nov-f6ba95\"},{\"uuid\":\"b612b280-1c5b-48cf-8c46-6a6ddc02eeb1\",\"name\":\"Wijziging
+        leerlingenvervoer doorgeven (asd)\",\"internalName\":\"\",\"slug\":\"wijziging-leerlingenvervoer-doorgeven-kopie\"},{\"uuid\":\"31520e77-f034-4151-9d17-0e4afc0574c5\",\"name\":\"Automatische
+        incasso\",\"internalName\":\"\",\"slug\":\"automatische-incasso\"},{\"uuid\":\"4d5a72a6-618b-4f7a-8187-c4cdfa5788f4\",\"name\":\"Issue
+        2699 - Files in repeating group\",\"internalName\":\"\",\"slug\":\"issue-2699-files-in-repeating-group\"},{\"uuid\":\"35e115e5-7981-45d8-acc9-adf454cff66b\",\"name\":\"Berekeningen
+        demo\",\"internalName\":\"\",\"slug\":\"berekeningen-demo\"},{\"uuid\":\"b2f5b0d3-26e9-45c9-8d4a-a17007756248\",\"name\":\"Demo
+        - Advanced logic\",\"internalName\":\"\",\"slug\":\"demo-advanced-logic\"},{\"uuid\":\"5aabf1c9-0bf2-46a6-9bfb-6f1464cadb6c\",\"name\":\"Hoe
+        vraag ik een nieuw locatiedossier aan?\",\"internalName\":\"Formulier nieuw
+        locatiedossier\",\"slug\":\"hoe-vraag-ik-een-nieuw-locatiedossier-aan\"},{\"uuid\":\"904d8957-0102-4ae0-b8da-761288eb5234\",\"name\":\"Many
+        steps\",\"internalName\":\"\",\"slug\":\"logic-breaks-after-user-variable\"},{\"uuid\":\"9073725e-8f43-4a73-a64a-309dfb0a48e1\",\"name\":\"Voorbeeld
+        formulier voor aanmaken zaak\",\"internalName\":\"Voorbeeldformulier OIP/OZ/OF:
+        Aanvragen rijbewijs\",\"slug\":\"bart-open-inwoner-zgw\"},{\"uuid\":\"99c95d40-fb60-412a-8de0-67cd735c99b7\",\"name\":\"testradiovalue\",\"internalName\":\"\",\"slug\":\"testradiovalue-a6c69a\"},{\"uuid\":\"6fccbdf3-34d7-453f-904a-24d801681e39\",\"name\":\"Issue
+        - File upload not accepted\",\"internalName\":\"\",\"slug\":\"issue-file-upload-not-accepted\"},{\"uuid\":\"69cb705d-190c-41a4-ae0d-7b24c818b72a\",\"name\":\"Wijziging
+        leerlingenvervoer doorgeven (asd) (asd)\",\"internalName\":\"\",\"slug\":\"wijziging-leerlingenvervoer-doorgeven-kopie-kopie\"},{\"uuid\":\"1c089836-dbbf-40c5-821b-5aa0513b03c7\",\"name\":\"BSNofKVK\",\"internalName\":\"\",\"slug\":\"bsnofkvk\"},{\"uuid\":\"b0623882-d4a4-4ded-b8f4-4516ce5e475b\",\"name\":\"Kwijtschelding
+        belasting aanvragen\",\"internalName\":\"\",\"slug\":\"kwijtschelding-belasting-aanvragen\"},{\"uuid\":\"5258d970-fa8a-4fd4-bdad-ea8ab2553a71\",\"name\":\"Sprint
+        13 demo\",\"internalName\":\"\",\"slug\":\"sprint-13-demo\"},{\"uuid\":\"29bd267f-07d7-41c1-ae39-90bb550f9425\",\"name\":\"Aanmelden
+        afscheid burgemeester\",\"internalName\":\"Afscheid burgemeester aanmelden
+        [Mail]\",\"slug\":\"aanmelden-afscheid-burgemeester-023cfc\"},{\"uuid\":\"25fc2076-f4fc-4fa9-9e26-bc4e32706070\",\"name\":\"klachtindienen\",\"internalName\":\"\",\"slug\":\"klacht-indienen\"},{\"uuid\":\"f0554cb7-d0f2-40f0-afe9-9e494b381034\",\"name\":\"testutrechtexxellence\",\"internalName\":\"\",\"slug\":\"testutrechtexxellence\"},{\"uuid\":\"9cca00d2-8ae7-4830-8361-91de4b297645\",\"name\":\"testformmaykingDELETEME\",\"internalName\":\"\",\"slug\":\"test-hedda-22-nov-205de1\"},{\"uuid\":\"17f73268-10b5-4539-89b9-de654b2ddaae\",\"name\":\"Test
+        format summary page\",\"internalName\":\"\",\"slug\":\"test-format-summary-page\"},{\"uuid\":\"cf74cd4e-fdda-4fa7-bdde-c00892512c4e\",\"name\":\"datetimebug2xx\",\"internalName\":\"\",\"slug\":\"datetimebug\"},{\"uuid\":\"65e65b17-f699-4643-90e2-dd68e3f0df36\",\"name\":\"Noodhulpetestutrecht\",\"internalName\":\"\",\"slug\":\"noodhulp\"},{\"uuid\":\"675b927c-00f0-4ed3-be58-b9be89985f05\",\"name\":\"Issue
+        DH - Email styling\",\"internalName\":\"\",\"slug\":\"issue-dh-email-styling\"},{\"uuid\":\"f3811ee6-69a6-4288-8933-1ab3940b31b3\",\"name\":\"Aanmelden
+        bijeenkomst\",\"internalName\":\"Aanmelden bijeenkomst standaard [Mail]\",\"slug\":\"aanmelden-bijeenkomst-dcec58\"},{\"uuid\":\"fbfe83fc-bc81-4cd9-9443-f917fb00e38c\",\"name\":\"Issue
+        2945 - Adding variables removes trigger\",\"internalName\":\"\",\"slug\":\"issue-2945-adding-variables-removes-trigger\"},{\"uuid\":\"9508dd9d-f9a7-4838-b16e-87c049bd3e22\",\"name\":\"Maykin
+        test- Uploads\",\"internalName\":\"\",\"slug\":\"maykin-test-uploadfields\"},{\"uuid\":\"49d24cd7-4f83-4270-833b-e81ec2211c14\",\"name\":\"Issue
+        XXXX - Config not respected for object api registration 1\",\"internalName\":\"\",\"slug\":\"issue-xxxx-config-not-respected-for-object-api-registration-1\"},{\"uuid\":\"caf59151-9a36-4bb1-837a-a36ef6589020\",\"name\":\"quarter
+        today and birthday\",\"internalName\":\"\",\"slug\":\"quartertodayandbirthday\"},{\"uuid\":\"383b493e-34ae-4832-809a-c636a678946b\",\"name\":\"Sprint
+        14 demonstratie\",\"internalName\":\"Sprint 14 demo\",\"slug\":\"sprint-14-demo\"},{\"uuid\":\"ea5590e0-e549-4004-8860-153e01fb2ae6\",\"name\":\"testverwijderenstappenmetidentiekecomponentnen\",\"internalName\":\"\",\"slug\":\"testverwijderenstappenmetidentiekecomponentnen\"},{\"uuid\":\"a713d625-17bb-4058-a6c7-da854ee05e59\",\"name\":\"Wijzigingsformulier
+        Kinderopvang (KO)\",\"internalName\":\"\",\"slug\":\"wijzigingsformulier-kinderopvang-ko\"},{\"uuid\":\"1caef644-df7b-4ba6-841b-6e7a9fb660d1\",\"name\":\"testvariable
+        duplicates\",\"internalName\":\"\",\"slug\":\"testvariable-duplicates\"},{\"uuid\":\"913c71b0-69e6-4b5a-bf94-e5ff6fbd4440\",\"name\":\"Aanvraag
+        mantelzorgcompliment\",\"internalName\":\"\",\"slug\":\"aanvraag-mantelzorgcompliment\"},{\"uuid\":\"7329b070-7866-43e9-ab39-8c6e48b0a624\",\"name\":\"Wijzigingsformulier
+        Kinderopvang (KO)\",\"internalName\":\"\",\"slug\":\"wijzigingsformulier-kinderopvang-ko-66fb98\"},{\"uuid\":\"4bc6ae00-8544-40e1-b22a-905d3e65539e\",\"name\":\"unhidden
+        by xy\",\"internalName\":\"\",\"slug\":\"unhidden-by-x\"},{\"uuid\":\"98356fdc-894c-4b3b-93dd-3dc8f8fbd85c\",\"name\":\"laurenstestbelastingsdienst\",\"internalName\":\"\",\"slug\":\"laurenstestbelastingsdienst\"},{\"uuid\":\"952031b9-efb5-4316-951b-fbd15961260d\",\"name\":\"Skips
+        (kopie)\",\"internalName\":\"\",\"slug\":\"skips-kopie\"},{\"uuid\":\"488ae29b-4afb-4d99-92e4-1482a321d844\",\"name\":\"HHG
+        met logica\",\"internalName\":\"\",\"slug\":\"hhg-met-logica\"},{\"uuid\":\"85812af1-3f30-4ab5-b4c3-f7bbf6a17363\",\"name\":\"Voorbeeld
+        - Dynamische opties in Radio\",\"internalName\":\"\",\"slug\":\"voorbeeld-dynamische-opties-in-radio\"},{\"uuid\":\"f5981be1-ceba-4bd1-8607-4a2703206ba7\",\"name\":\"Open
+        Inwoner ZGW Test\",\"internalName\":\"\",\"slug\":\"open-inwoner-zgw-test\"},{\"uuid\":\"bfdaf093-8656-4454-a0db-4c433ddb06df\",\"name\":\"Wijzigingsformulier
+        bijstandsuitkering\",\"internalName\":\"\",\"slug\":\"wijzigingsformulier-bijstandsuitkering\"},{\"uuid\":\"5af0c5f4-8260-470c-a92d-0ade8c571312\",\"name\":\"verhuismelding\",\"internalName\":\"\",\"slug\":\"verhuismelding-0\"},{\"uuid\":\"27d814a4-6d13-454c-beef-e3215f047cd7\",\"name\":\"Repeating
+        groups\",\"internalName\":\"\",\"slug\":\"repeating-groups\"},{\"uuid\":\"4432dd5a-9cdd-4012-b5ea-ac691a295013\",\"name\":\"Math\",\"internalName\":\"\",\"slug\":\"math\"},{\"uuid\":\"d9597d0c-653e-4082-b8a1-532318f2ac7a\",\"name\":\"Skips\",\"internalName\":\"\",\"slug\":\"skips\"},{\"uuid\":\"cd99b9d2-f5f2-45b7-bff6-3fc76f56a901\",\"name\":\"Phone
+        number component\",\"internalName\":\"\",\"slug\":\"phone-number-component\"},{\"uuid\":\"3cf06e02-3aed-4d1e-b52d-e276e50a82b4\",\"name\":\"test
+        logic breaking when group is used\",\"internalName\":\"\",\"slug\":\"test-logic-breaking-when-group-is-used\"},{\"uuid\":\"e1576990-affe-4e77-963a-752c13b2954d\",\"name\":\"Subsidie
+        afkoppelen hemelwater en afvalwater (Decos JOIN test kopie)\",\"internalName\":\"\",\"slug\":\"subsidie-afkoppelen-hemelwater-en-afvalwater-kopie\"},{\"uuid\":\"e2a862b5-1cfb-4291-be40-03ca41615bfc\",\"name\":\"Aanvraag
+        briefadres\",\"internalName\":\"\",\"slug\":\"aanvraag-briefadres\"},{\"uuid\":\"e045b4b9-e55a-44ea-bb12-a5aaf086f030\",\"name\":\"Leerlingenvervoer
+        2022/2023\",\"internalName\":\"\",\"slug\":\"leerlingenvervoer-20222023-3769ca\"},{\"uuid\":\"cb709db4-5cc8-4ab8-acfa-7a133e513469\",\"name\":\"Waar
+        kan ik mijn klacht melden? (kopie)\",\"internalName\":\"Formulier klachtenoverzicht
+        (nu echt goed)\",\"slug\":\"klachtenoverzicht2\"},{\"uuid\":\"44ca90fc-accd-429d-8f7a-89bb93b0d4c1\",\"name\":\"Informatie
+        uit het bouwarchief opvragen\",\"internalName\":\"\",\"slug\":\"bouwarchief\"},{\"uuid\":\"e9c35d01-2ef9-48a5-92e6-63b1f1c2d085\",\"name\":\"Leerlingenvervoer
+        2023/2024\",\"internalName\":\"\",\"slug\":\"leerlingenvervoer-20232024\"},{\"uuid\":\"d89260cd-54e4-48b7-adba-741652f9e3c4\",\"name\":\"Toeristenbelasting
+        aangifte\",\"internalName\":\"\",\"slug\":\"toeristenbelasting-aangifte\"},{\"uuid\":\"aeb3ca14-5a0a-4eef-a1bf-b0768f11c8bf\",\"name\":\"breakingmultiplenonapplicablesteps\",\"internalName\":\"\",\"slug\":\"breakingmultiplenonapplicablesteps\"},{\"uuid\":\"1dba0bfc-f480-4728-b58f-8563cda98e0e\",\"name\":\"Aanvraag
+        rioolaansluiting\",\"internalName\":\"\",\"slug\":\"aanvraag-rioolaansluiting-fa52b9\"},{\"uuid\":\"39ab63fa-26f3-41a9-a021-ff1fb889e3a9\",\"name\":\"\",\"internalName\":\"Afscheid
+        burgemeester aanmelden [Mail]\",\"slug\":\"aanmelden-afscheid-burgemeester\"},{\"uuid\":\"6b140618-7da2-45d9-af16-28d3b209110b\",\"name\":\"Marktplaatsvergunning
+        aanvragen\",\"internalName\":\"\",\"slug\":\"marktplaatsvergunning-aanvragen\"},{\"uuid\":\"439c9ce7-b486-409b-bb55-286de6fb3f6f\",\"name\":\"Leerlingenvervoer\",\"internalName\":\"Leerlingenvervoer\",\"slug\":\"leerlingenvervoer\"},{\"uuid\":\"30bec177-da83-435d-9f99-3a4d388fd6e1\",\"name\":\"Test
+        simple upload\",\"internalName\":\"\",\"slug\":\"test-simple-upload\"},{\"uuid\":\"f5659e3f-08b1-4d2b-88cd-5031e35111a7\",\"name\":\"Voorbeeld
+        weergave\",\"internalName\":\"\",\"slug\":\"voorbeeld-weergave\"},{\"uuid\":\"197c477b-15a3-4b07-860a-ca565eb18894\",\"name\":\"Ooievaarspas
+        aanvragen\",\"internalName\":\"Ooievaarspas\",\"slug\":\"aanvraag-formulier-ooievaarspas-a38bea\"},{\"uuid\":\"dc67cba3-79eb-4a46-9a47-e7c9bed86509\",\"name\":\"Aanmelden
+        bijeenkomst\",\"internalName\":\"Aanmelden bijeenkomst standaard [Mail]\",\"slug\":\"aanmelden-bijeenkomst-7c5fac\"},{\"uuid\":\"a0f01777-95f8-4022-bef0-c915c6ebcf7f\",\"name\":\"Wijzigingsformulier\",\"internalName\":\"RSD0010
+        Wijzigingsformulier\",\"slug\":\"wijzigingsformulier-87a067\"},{\"uuid\":\"d28ec493-ed36-4731-86d9-ae2c76c7a3c2\",\"name\":\"odru\",\"internalName\":\"\",\"slug\":\"odru\"},{\"uuid\":\"9beb73ff-7340-4f4f-89e9-12660e01161b\",\"name\":\"Contact
+        met gemeente\",\"internalName\":\"\",\"slug\":\"contact-met-gemeente-b90dab\"},{\"uuid\":\"05cfadc2-33b3-4ab0-8b20-9eb0e9fbb395\",\"name\":\"taiga-dh-36\",\"internalName\":\"\",\"slug\":\"taiga-dh-36\"},{\"uuid\":\"75ef9c30-c0d2-419f-b187-f363f32ce458\",\"name\":\"test
+        date widget\",\"internalName\":\"Issue: test date widget GH 1575\",\"slug\":\"issue-test-date-widget\"},{\"uuid\":\"49c2e20b-4fab-4a7b-ae4a-ab9d69d73e32\",\"name\":\"Afschrift
+        GBA aanvragen\",\"internalName\":\"\",\"slug\":\"afschrift-uit-de-basisregistratie-personen-aanvragen\"},{\"uuid\":\"203c3114-37cf-4a31-8ebd-be9e6419d10c\",\"name\":\"asdasdzxczxczxccasasdas\",\"internalName\":\"\",\"slug\":\"zxcczcasdasdzxczxczxccasasdas\"},{\"uuid\":\"25124532-a3c3-421c-b1f4-d531ec095777\",\"name\":\"Alcoholwet-
+        of exploitatievergunning veranderen\",\"internalName\":\"\",\"slug\":\"drank-en-horecavergunning-of-exploitatievergunning-veranderen\"},{\"uuid\":\"da31373f-6198-4290-9ac3-485527bd5c6a\",\"name\":\"Leerlingenvervoer
+        voortgezet onderwijs en voortgezet speciaal onderwijs\",\"internalName\":\"\",\"slug\":\"leerlingenvervoer-voortgezet-onderwijs-en-voortgezet-speciaal-onderwijs-vovso\"},{\"uuid\":\"b5267dd4-c8d3-4f48-a11d-e796c2eaae88\",\"name\":\"Wijzigingsformulier\",\"internalName\":\"RSD0010
+        Wijzigingsformulier\",\"slug\":\"wijzigingsformulier-d5dabc\"},{\"uuid\":\"f17f54f7-010b-4c55-81ab-965ce41ab84e\",\"name\":\"Vraag
+        of klacht\",\"internalName\":\"\",\"slug\":\"123\"},{\"uuid\":\"0a21d325-4a4e-4005-a4ec-2b204a711657\",\"name\":\"calculating\",\"internalName\":\"\",\"slug\":\"calculating\"},{\"uuid\":\"bed18ae9-67a2-469e-8aec-f98ec5295993\",\"name\":\"testsnelheid\",\"internalName\":\"\",\"slug\":\"testsnelheid\"},{\"uuid\":\"7667c1f0-9176-4c5b-b50f-59b16ee41355\",\"name\":\"Test
+        data clearing\",\"internalName\":\"\",\"slug\":\"test-data-clearing\"},{\"uuid\":\"21bd00ff-27e7-445c-a32a-1fff929696fc\",\"name\":\"Bart
+        Test Image Size\",\"internalName\":\"\",\"slug\":\"bart-test-image-size\"},{\"uuid\":\"c2dfd18a-b0cd-4dfa-9b97-0b253bc7ca4f\",\"name\":\"Logic
+        dates\",\"internalName\":\"\",\"slug\":\"datedatetime\"},{\"uuid\":\"c4de1323-d16c-45b8-9923-03eeb4d8516d\",\"name\":\"Vooroverleg\",\"internalName\":\"\",\"slug\":\"vooroverleg\"},{\"uuid\":\"9346b78a-cc24-4074-8720-8c1aa242e973\",\"name\":\"Rioolaansluiting
+        aanvragen\",\"internalName\":\"\",\"slug\":\"rioolaansluiting-aanvragen\"},{\"uuid\":\"406e1323-887c-4260-a38c-c193683e3624\",\"name\":\"Bart
+        Test Summary\",\"internalName\":\"\",\"slug\":\"bart-test-summary\"},{\"uuid\":\"95dd6b2e-2cb4-4bfd-9690-23a4bebabe55\",\"name\":\"Test
+        Adam\",\"internalName\":\"\",\"slug\":\"test-adam\"},{\"uuid\":\"0f5f104d-63c4-4591-9730-647fee5e8f3d\",\"name\":\"Aanvraag
+        paspoort\",\"internalName\":\"\",\"slug\":\"taiga_167\"},{\"uuid\":\"3a15f886-cf8d-4e8a-b413-b665ff5cfc53\",\"name\":\"Test
+        Prefill\",\"internalName\":\"\",\"slug\":\"test-prefill\"},{\"uuid\":\"191eae69-595d-48ef-a246-5e3346d37335\",\"name\":\"Maykin
+        Test - Prefill plugin: StUF-BG (PinkRoccade Makelaarsuite - Horst a/d Maas)\",\"internalName\":\"\",\"slug\":\"maykin-test-prefill-plugin-stuf-bg-pinkroccade-makelaarsuite-horst-d-maas\"},{\"uuid\":\"f55113ce-69ff-453c-b316-44b2b9c38b9f\",\"name\":\"Klantevaluatie
+        Maykin Media\",\"internalName\":\"\",\"slug\":\"klant-evaluatie\"},{\"uuid\":\"cff5921a-a4b8-45cf-abb7-ecb1a6f855f9\",\"name\":\"Test
+        issue 1128\",\"internalName\":\"\",\"slug\":\"test-issue-1128\"},{\"uuid\":\"ebf0303e-611c-4d62-b134-b59d3f5fdb88\",\"name\":\"Bart
+        Test - Uploads (old)\",\"internalName\":\"\",\"slug\":\"test-uploads-old\"},{\"uuid\":\"8391ab31-bf1c-48e0-8694-1a8a8bef8781\",\"name\":\"Aanvraagformulier
+        Financi\xEBle Ondersteuning Ondernemers\",\"internalName\":\"Financiele Ondersteuning
+        Ondernemers\",\"slug\":\"aanvraagformulier-financiele-ondersteuning-ondernemers-cfceea\"},{\"uuid\":\"ccfccdea-e5a7-40d7-a20e-7917f1d559de\",\"name\":\"Issue:
+        Logic not always blocks step\",\"internalName\":\"\",\"slug\":\"issue-logic-not-always-blocks-step\"},{\"uuid\":\"fc89ac86-6cad-4ce5-a1d4-a2e06fe5ce71\",\"name\":\"Inschrijfformulier
+        kermis Venray-Centrum\",\"internalName\":\"\",\"slug\":\"inschrijfformulier-kermis-venray-centrum\"},{\"uuid\":\"b1987076-aa2d-44c6-ace8-691b9590442d\",\"name\":\"Issue
+        2058 - Hidden groups in summary\",\"internalName\":\"\",\"slug\":\"issue-2058-hidden-groups-in-summary\"},{\"uuid\":\"8321765f-92b2-4044-b9d2-e6d337ba2414\",\"name\":\"foobar2\",\"internalName\":\"\",\"slug\":\"foobar2\"},{\"uuid\":\"27dc098d-eea8-4ca8-b67b-7ca4e24819c6\",\"name\":\"Principeverzoek\",\"internalName\":\"\",\"slug\":\"principeverzoek-8eb4ce\"},{\"uuid\":\"e2a7d318-6ef6-4c9f-8fa4-dc081cc8a393\",\"name\":\"Test
+        Inloggen EHerkenning\",\"internalName\":\"\",\"slug\":\"test-inloggen-eherkenning\"},{\"uuid\":\"c1737064-a8ef-49ed-95f6-fe2c9b1c357b\",\"name\":\"Velden
+        op basis van inlogmethode\",\"internalName\":\"Velden op basis van inlogmethode
+        (documentatie)\",\"slug\":\"velden-op-basis-van-inlogmethode\"},{\"uuid\":\"c49f06e9-a337-4014-8241-63ce3551716c\",\"name\":\"test:
+        error & warning scroll to top\",\"internalName\":\"\",\"slug\":\"errorscrolltotop\"},{\"uuid\":\"5a35bc55-5042-44af-a6fc-8fb59f5cc2dc\",\"name\":\"Simple\",\"internalName\":\"\",\"slug\":\"simple-7e5ee8\"},{\"uuid\":\"04955007-b638-437c-bc2f-35f04380a35f\",\"name\":\"testdigidprefillstufbg\",\"internalName\":\"\",\"slug\":\"testdigidprefillstufbg\"},{\"uuid\":\"be56a2be-68b4-41c3-90c4-bc0f188806e0\",\"name\":\"Figure
+        out logic order\",\"internalName\":\"\",\"slug\":\"figure-out-logic-order-56dccf\"},{\"uuid\":\"1ecc7367-aea2-438c-8daf-8687b613a54b\",\"name\":\"Issue:
+        Logic visibility toggle\",\"internalName\":\"Issue: Logic visibility toggle:
+        DH taiga 30\",\"slug\":\"issue-logic-visibility-toggle\"},{\"uuid\":\"1b882652-efd9-4a00-a9ee-a72e745b8079\",\"name\":\"Uittreksel
+        GBA aanvragen (demo)\",\"internalName\":\"\",\"slug\":\"uittreksel-gba\"},{\"uuid\":\"607005d7-e274-4694-83a5-0915d35fb5d5\",\"name\":\"Bart
+        Test Field Casing #879\",\"internalName\":\"\",\"slug\":\"bart-test-field-casing\"},{\"uuid\":\"cacb8eea-99e3-4133-b858-85ef6832b1f9\",\"name\":\"Test
+        Upload\",\"internalName\":\"\",\"slug\":\"bart-test-upload2\"},{\"uuid\":\"e8224bb8-3276-4a95-aa7a-aad7f25bd817\",\"name\":\"Simple\",\"internalName\":\"\",\"slug\":\"simple\"},{\"uuid\":\"95882db9-7f79-4602-a577-7058cc03a3b8\",\"name\":\"Velden
+        op basis van inlogmethode\",\"internalName\":\"\",\"slug\":\"voorbeeld-velden-op-basis-van-inlogmethode\"},{\"uuid\":\"1c453fc8-b10f-4510-b5d2-43934ccb19ed\",\"name\":\"Workflow
+        proces\",\"internalName\":\"\",\"slug\":\"workflow-proces\"},{\"uuid\":\"4d5dda29-e6e0-4010-9450-e03c578959ed\",\"name\":\"Aanvraag
+        periodieke subsidie\",\"internalName\":\"\",\"slug\":\"aanvraag-periodieke-subsidie-6b76aa\"},{\"uuid\":\"ea6ec7fb-9a9a-4b83-89fd-2bfc41eef3c8\",\"name\":\"Issue:
+        Typen in select widget\",\"internalName\":\"Issue: Typen in select widget
+        DH taiga 29\",\"slug\":\"issue-typen-in-select-widget-3dd53c\"},{\"uuid\":\"bbb0e33b-8994-4a0f-ae7e-c393bb91f35e\",\"name\":\"testfailure\",\"internalName\":\"\",\"slug\":\"testfailure\"},{\"uuid\":\"4d56c3af-3067-4077-83df-fdd3b23c020e\",\"name\":\"test
+        date widget\",\"internalName\":\"Issue: test date widget GH 1575\",\"slug\":\"issue-test-date-widget-52bc7d\"},{\"uuid\":\"80d4c657-cb9c-4157-8123-7dee8bc279a6\",\"name\":\"Figure
+        out logic order\",\"internalName\":\"Test Marie\",\"slug\":\"figure-out-logic-order-aabd5a\"},{\"uuid\":\"fdb54bc2-322f-472c-80b5-5031866f1934\",\"name\":\"Issue:
+        Typen in select widget\",\"internalName\":\"Issue: Typen in select widget
+        DH taiga 29\",\"slug\":\"issue-typen-in-select-widget\"},{\"uuid\":\"adb393e6-6aad-4c54-9643-ee2c45191a1f\",\"name\":\"Test
+        logic with fieldsets\",\"internalName\":\"\",\"slug\":\"test-logic-fieldsets\"},{\"uuid\":\"17688bb7-4d8d-46e3-8d2d-67bc992e59d2\",\"name\":\"kortenaam\",\"internalName\":\"\",\"slug\":\"maykin-test-registation-plugin-msazure\"},{\"uuid\":\"2b7f8b24-cfc7-477b-870f-f5d5cc03a8b5\",\"name\":\"Demo
+        22 november 2021\",\"internalName\":\"\",\"slug\":\"demo-22-november-2021\"},{\"uuid\":\"48e28bbe-b589-4494-9812-05b8b13d09ad\",\"name\":\"Issue
+        971\",\"internalName\":\"\",\"slug\":\"issue-971\"},{\"uuid\":\"630cc679-1656-45d0-8b27-05391927ed9a\",\"name\":\"Wijzigingsformulier\",\"internalName\":\"RSD0010
+        Wijzigingsformulier\",\"slug\":\"wijzigingsformulier\"},{\"uuid\":\"e3face1e-e5a2-4641-bee5-60029f521a54\",\"name\":\"Test
+        Saving form\",\"internalName\":\"\",\"slug\":\"test-saving-form\"},{\"uuid\":\"460379d2-5449-4247-a783-78d04aaa84d5\",\"name\":\"Maykin
+        Test - Registration plugin: ZGW API's\",\"internalName\":\"\",\"slug\":\"maykin-test-registration-plugin-zgw-apis\"},{\"uuid\":\"103b6a6a-cee8-4fe1-89a1-ec4eda9f2b56\",\"name\":\"Maykin
+        Test - Authentication plugin: eIDAS\",\"internalName\":\"\",\"slug\":\"maykin-test-authentication-plugin-eidas\"},{\"uuid\":\"143fa866-14c0-4a54-ad2c-bdacf85cedb4\",\"name\":\"Vraag
+        of klacht\",\"internalName\":\"Formulier t.b.v. Logius test procedure\",\"slug\":\"vraag-of-klacht\"},{\"uuid\":\"6637f821-eec5-4c8d-ae71-571211133a6b\",\"name\":\"Afspraak-test\",\"internalName\":\"\",\"slug\":\"afspraak-test\"},{\"uuid\":\"fd9a5d3e-68d4-49f5-a9e0-0a3c35aa168f\",\"name\":\"Registratie
+        Open Bedrijven Dag\",\"internalName\":\"\",\"slug\":\"registratie-open-bedrijven-dag\"},{\"uuid\":\"48446b25-b338-4025-9f5e-692ea036cdb3\",\"name\":\"Test
+        no registration backend\",\"internalName\":\"\",\"slug\":\"test-no-registration-backend\"},{\"uuid\":\"8e12bae5-8cb9-4e0b-9a3d-61bee2a447a2\",\"name\":\"Paspoort
+        of identiteitsbewijs aanvragen\",\"internalName\":\"\",\"slug\":\"paspoort-identiteitsbewijs-aanvragen\"},{\"uuid\":\"6fd78c28-d91b-40f7-8ba8-c73989c3df7d\",\"name\":\"Maykin
+        Test - Registration plugin: StUF-ZDS (BCT Corsa - Lab)\",\"internalName\":\"\",\"slug\":\"registration-plugin-stuf-zds-bct-corsa-lab\"},{\"uuid\":\"4da4c3ea-8067-4929-81bc-c73b8becd2b0\",\"name\":\"Maykin
+        Test - Prefill plugin: BAG\",\"internalName\":\"\",\"slug\":\"test-bag\"},{\"uuid\":\"bd5cf10a-c11e-4bf0-bb61-ab868d64da09\",\"name\":\"Maykin
+        Test - Appointment plugin: Qmatic TODO\",\"internalName\":\"\",\"slug\":\"maykin-test-appointment-plugin-qmatic\"},{\"uuid\":\"1cb8807f-4ce1-4882-a66e-12b69d59b4f4\",\"name\":\"Maykin
+        Test - Registration plugin: StUF-ZDS (Excellence - Utrecht) TODO\",\"internalName\":\"\",\"slug\":\"registration-plugin-stuf-zds-excellence-utrecht\"},{\"uuid\":\"b829ff4a-193b-43e9-b662-4e449338fd8d\",\"name\":\"Vrij
+        testen\",\"internalName\":\"\",\"slug\":\"vrij-testen\"},{\"uuid\":\"c943a26c-ffdc-45b9-9d12-8bbdb6bb68cb\",\"name\":\"issue
+        1\",\"internalName\":\"\",\"slug\":\"issue-1\"},{\"uuid\":\"fbe2106a-7215-4cf3-b916-da0c371e5aaa\",\"name\":\"Maykin
+        Test - Prefill plugin: Haal Centraal BRP bevragen\",\"internalName\":\"\",\"slug\":\"maykin-test-prefill-plugin-haal-centraal-brp-bevragen\"},{\"uuid\":\"785d01e1-02e7-4ce9-b636-cd12bc45975e\",\"name\":\"Test
+        met Haarlem\",\"internalName\":\"\",\"slug\":\"test-met-haarlem\"},{\"uuid\":\"d616fa38-3d52-4614-857f-8c99fdac7438\",\"name\":\"Demo
+        28 oktober\",\"internalName\":\"\",\"slug\":\"demo-28-oktober\"},{\"uuid\":\"ec8ab8c3-01cf-4b6c-8319-b4e9c2168e4e\",\"name\":\"Bart
+        Test - Upload\",\"internalName\":\"\",\"slug\":\"bart-test-upload\"},{\"uuid\":\"f47c4295-dcac-409c-ab07-1c7a049fcc7c\",\"name\":\"KvK
+        demo\",\"internalName\":\"\",\"slug\":\"kvk-demo\"},{\"uuid\":\"0d8498e6-ce1a-4669-aeb4-d516d810f030\",\"name\":\"Figure
+        out logic order\",\"internalName\":\"\",\"slug\":\"figure-out-logic-order\"},{\"uuid\":\"a6a5330a-d6f1-41a0-917e-5c76a9ab0a0e\",\"name\":\"Maykin
+        Test - Registration plugin: Email\",\"internalName\":\"\",\"slug\":\"maykin-test-registration-plugin-email\"},{\"uuid\":\"43771973-d0e8-446d-9f0e-dfa43f4f2244\",\"name\":\"Test
+        advanced logic front end\",\"internalName\":\"\",\"slug\":\"test-advanced-logic-front-end-dae49d\"},{\"uuid\":\"a87dc728-bb78-4624-aa5a-e060b4421c49\",\"name\":\"Maykin
+        Test - Registration plugin: Local (no backend)\",\"internalName\":\"\",\"slug\":\"maykin-test-registration-plugin-local-no-backend\"},{\"uuid\":\"8f51e712-a9ba-43ca-b010-f12945b4037c\",\"name\":\"Maykin
+        Test - Registration plugin: Objects API - TODO\",\"internalName\":\"\",\"slug\":\"maykin-test-registration-plugin-objects-api\"},{\"uuid\":\"3cafdd93-9b83-4c94-853d-bbbbf2017656\",\"name\":\"Maykin
+        Test - Appointment plugin: JCC (Horst a/d Maas)\",\"internalName\":\"\",\"slug\":\"test-afspraken\"},{\"uuid\":\"d2b03c3d-c5f6-4591-8e74-2cc00a668bb0\",\"name\":\"Adres
+        demo (oud)\",\"internalName\":\"\",\"slug\":\"adres-demo\"},{\"uuid\":\"337de759-c5de-4f6b-8768-96038c443aa4\",\"name\":\"Maykin
+        Test - Authentication plugin: eHerkenning\",\"internalName\":\"\",\"slug\":\"maykin-test-authentication-plugin-eherkenning\"},{\"uuid\":\"55620c48-d219-4ad3-ac4d-6b28ef37483c\",\"name\":\"Test
+        content-component text color\",\"internalName\":\"\",\"slug\":\"test-content-component-text-color\"},{\"uuid\":\"6eb176b2-17d4-4a8b-be23-5955290f4825\",\"name\":\"Dossiers
+        Vergunningverlening, toezicht en handhaving opvragen - oud\",\"internalName\":\"\",\"slug\":\"dossiers-vth-oud\"},{\"uuid\":\"488b653d-8dfb-455d-abad-9c6dc3eb23a2\",\"name\":\"Taiga
+        Vught 9\",\"internalName\":\"\",\"slug\":\"taiga-vught-9\"},{\"uuid\":\"e9613d9c-22e6-4e07-acc8-4112366bbd23\",\"name\":\"Herhalende
+        groep demo\",\"internalName\":\"\",\"slug\":\"herhalende-groep-demo\"},{\"uuid\":\"984ef81b-bfa5-4315-ae8e-e6e8ce4d89b2\",\"name\":\"Maykin
+        Test - Authentication plugin: DigiD\",\"internalName\":\"\",\"slug\":\"authentication-plugin-digid\"},{\"uuid\":\"69ea37e8-bb6a-4a86-92bc-e158442c401b\",\"name\":\"testvenrrr
+        (kopie)\",\"internalName\":\"\",\"slug\":\"venrtest34-kopie-2-f0bd2d\"},{\"uuid\":\"6cb48c7b-08d4-409c-845e-23be426f1309\",\"name\":\"testverplicht\",\"internalName\":\"\",\"slug\":\"testverplicht\"},{\"uuid\":\"42d26593-358b-4ae6-8325-84aeaae94fb6\",\"name\":\"Test
+        Taiga 170 DH\",\"internalName\":\"\",\"slug\":\"test-taiga-170-dh\"},{\"uuid\":\"61ffd593-8a1d-4463-901e-bfe7dc5ade0d\",\"name\":\"[DH
+        Demo] Aanvraag stadspas\",\"internalName\":\"\",\"slug\":\"dh-demo-aanvraag-stadspas-1\"},{\"uuid\":\"cc525101-ce69-4b32-96ac-26c96ccda1e3\",\"name\":\"Logic
+        check performance profiling\",\"internalName\":\"\",\"slug\":\"logic-check-performance-profiling\"},{\"uuid\":\"566abd23-2373-4953-bab7-5cfcc7025c91\",\"name\":\"Test
+        BSN logic\",\"internalName\":\"\",\"slug\":\"test-bsn-logic\"},{\"uuid\":\"5138d119-3c89-4bf0-8eba-5e56d354d86c\",\"name\":\"Simple\",\"internalName\":\"\",\"slug\":\"simple-ee2d66\"},{\"uuid\":\"969c913a-5b1e-4cca-ba49-2b04c0b3b955\",\"name\":\"Experiment
+        default values\",\"internalName\":\"\",\"slug\":\"experiment-default-values\"},{\"uuid\":\"33188b6a-48fa-4f87-a0ba-9a3a6b48cb00\",\"name\":\"even
+        met sjoerd\",\"internalName\":\"\",\"slug\":\"even-met-sjoerd\"},{\"uuid\":\"416c554f-9b77-4725-971f-60749866c190\",\"name\":\"Issue
+        2080 - Screen readers\",\"internalName\":\"\",\"slug\":\"issue-2080-screen-readers\"},{\"uuid\":\"140c91f1-390f-4990-97c3-8e078459a4ef\",\"name\":\"Test
+        @26\",\"internalName\":\"\",\"slug\":\"test26\"},{\"uuid\":\"94496ced-1cae-481c-93fe-5cb75cde783e\",\"name\":\"Test
+        terugzetten\",\"internalName\":\"\",\"slug\":\"test-terugzetten\"},{\"uuid\":\"28bb11b1-9a9e-4808-bfeb-bb8f4f1e95eb\",\"name\":\"testvenrrr\",\"internalName\":\"\",\"slug\":\"venrtest34\"},{\"uuid\":\"86a5dd7b-3358-4bee-bde7-49a5613953bf\",\"name\":\"Contact
+        met gemeente\",\"internalName\":\"\",\"slug\":\"contact-met-gemeente\"},{\"uuid\":\"58f20cde-a131-4252-9695-6c8ef16401fe\",\"name\":\"Bart
+        Test - Optionele Auth\",\"internalName\":\"\",\"slug\":\"bart-test-optionele-auth\"},{\"uuid\":\"80809188-2f92-43a0-b3e3-5d417cec4347\",\"name\":\"New
+        co-sign\",\"internalName\":\"\",\"slug\":\"new-co-sign\"},{\"uuid\":\"07b0e254-0550-4a9a-b0a4-863e69a70a3e\",\"name\":\"testvenrrr
+        (kopie)\",\"internalName\":\"\",\"slug\":\"venrtest34-kopie-2\"},{\"uuid\":\"b22fb0c7-c4e7-43c7-a788-aab29b1ed437\",\"name\":\"\\\"bedankt!\\\"
+        's-Gravenhagen/../joh!\",\"internalName\":\"\",\"slug\":\"metadata-signicat-prexml\"},{\"uuid\":\"de1c5b4c-35fb-4862-8c33-00dc3417277c\",\"name\":\"Inkomstenformulier\",\"internalName\":\"RSD0003
+        Inkomstenformulier\",\"slug\":\"inkomstenformulier\"},{\"uuid\":\"645634dc-80ba-4ff2-bb89-63cf386d5258\",\"name\":\"sjoerd
+        test\",\"internalName\":\"\",\"slug\":\"sjoerd-test\"},{\"uuid\":\"1181507b-444c-479f-913d-4c1948be0e22\",\"name\":\"Date\",\"internalName\":\"\",\"slug\":\"date\"},{\"uuid\":\"b6dea150-540d-41f2-9fef-a8d72db6bf6a\",\"name\":\"Bart
+        Test Import Export\",\"internalName\":\"\",\"slug\":\"bart-test-import-export\"},{\"uuid\":\"3531c7d9-ae76-4a3d-a670-2c7a45b75b95\",\"name\":\"Maykin
+        Test - Uploads\",\"internalName\":\"\",\"slug\":\"maykin-test-uploads\"},{\"uuid\":\"02ec3323-6088-4cda-ad39-a1edf3ce8e56\",\"name\":\"Dossiers
+        Vergunningverlening, toezicht en handhaving opvragen\",\"internalName\":\"\",\"slug\":\"dossiers-vth\"},{\"uuid\":\"33f5a0ab-d90d-4560-87f8-c519093bb939\",\"name\":\"Maykin
+        Test - Logica\",\"internalName\":\"\",\"slug\":\"test-logica\"},{\"uuid\":\"34ca02af-8b31-4c55-abf7-ad6f5137475b\",\"name\":\"Afspraak
+        annuleren\",\"internalName\":\"\",\"slug\":\"self-service\"},{\"uuid\":\"a887ebdc-0ada-46d3-94b6-c6a5f02b5515\",\"name\":\"Test
+        simple upload\",\"internalName\":\"\",\"slug\":\"test-simple-upload-3fee7a\"},{\"uuid\":\"fc39b7b3-30cf-4b98-a0b5-2ad5fd6464c3\",\"name\":\"Test
+        auth\",\"internalName\":\"\",\"slug\":\"test-auth\"},{\"uuid\":\"a2923b37-c275-4cdf-b3ed-96ad34948831\",\"name\":\"Bart
+        Meeting Test Form\",\"internalName\":\"\",\"slug\":\"bart-meeting-test-form\"},{\"uuid\":\"05cd776c-f9a1-49f4-ad6c-3dd061d05a22\",\"name\":\"Maykin
+        Test - Registration plugin: StUF-ZDS (BCT Liber - Lab)\",\"internalName\":\"\",\"slug\":\"registration-plugin-stuf-zds-bct-liber-lab\"},{\"uuid\":\"0bdd58b8-1bed-46f7-b63e-c8ed25dfeddf\",\"name\":\"Maykin
+        Test - Authentication plugin: OpenID Connect TODO STEVEN\",\"internalName\":\"\",\"slug\":\"maykin-test-authentication-plugin-openid-connect\"},{\"uuid\":\"f82d00c4-ee08-48ce-a55c-44f9b748cfc7\",\"name\":\"Automatische
+        incasso gemeentelijke heffingen\",\"internalName\":\"\",\"slug\":\"automatische-incasso-gemeentelijke-heffingen\"},{\"uuid\":\"da12d5f3-dd6c-475d-b18d-8bb900ae69fd\",\"name\":\"BSNofKVK\",\"internalName\":\"\",\"slug\":\"bsnofkvk-f0aedc\"},{\"uuid\":\"be2c58a2-9bcc-499a-8fa3-c439afa6c006\",\"name\":\"DH
+        Taiga 304 - Upload big files\",\"internalName\":\"\",\"slug\":\"dh-taiga-304-upload-big-files\"},{\"uuid\":\"b061ec26-fff1-46f4-8e21-69986c46e0f5\",\"name\":\"Mantelzorgcompliment
+        aanvragen\",\"internalName\":\"Mantelzorgcompliment aanvragen\",\"slug\":\"mantelzorgcompliment-aanvragen\"},{\"uuid\":\"cdc9b1f1-e214-4a66-8e8b-54deea973cbd\",\"name\":\"Test
+        escaping\",\"internalName\":\"\",\"slug\":\"test-escaping\"},{\"uuid\":\"0cfc6408-e66e-4952-ac8a-c28a44686981\",\"name\":\"Klacht
+        indienen\",\"internalName\":\"Klacht indienen\",\"slug\":\"klacht-indienen-08e594\"},{\"uuid\":\"fbb4ea51-c95c-4138-bf34-4c214d69b193\",\"name\":\"BAG-objectID\",\"internalName\":\"\",\"slug\":\"bag-objectid\"},{\"uuid\":\"ea1ccb3f-48e1-47fe-9e09-99ce8f467b0e\",\"name\":\"Adress
+        prefill problem\",\"internalName\":\"\",\"slug\":\"adress-prefill-problem\"},{\"uuid\":\"1dacaf4f-bc68-4197-8c7b-84ad7ec913c1\",\"name\":\"fetchplayground\",\"internalName\":\"\",\"slug\":\"sprint-15-demo-kopie\"},{\"uuid\":\"d32ac35f-cd7a-4a11-84b8-af59be5db0ff\",\"name\":\"tescsv
+        voor HHgroepen (kopie)\",\"internalName\":\"\",\"slug\":\"tescsv-voor-hhgroepen-copy\"},{\"uuid\":\"c0aeee2d-10e4-4ce9-9b86-fa7211e56087\",\"name\":\"Bijbehorend
+        bouwwerk in het achtererfgebied\",\"internalName\":\"\",\"slug\":\"bijbehorend-bouwwerk-achtererfgebied\"},{\"uuid\":\"bb107d8b-e857-4deb-bd00-8d7f1955d4bf\",\"name\":\"Aanvraagformulier
+        nadeelcompensatie\",\"internalName\":\"\",\"slug\":\"nadeelcompensatie\"},{\"uuid\":\"98cc2dfa-234f-4c9c-b6bc-49ad28a8e285\",\"name\":\"gezin\",\"internalName\":\"\",\"slug\":\"gezin\"},{\"uuid\":\"e188d483-c41a-473f-81b9-a4563de6a265\",\"name\":\"testhugejson\",\"internalName\":\"\",\"slug\":\"testhugejson\"},{\"uuid\":\"def1f4d6-aa0b-4163-9f4e-1e7b22e8959a\",\"name\":\"testing11
+        (kopie)\",\"internalName\":\"\",\"slug\":\"testing11-kopie\"},{\"uuid\":\"00705c7b-c4b3-4c96-accf-321bda7748a2\",\"name\":\"testing11\",\"internalName\":\"\",\"slug\":\"testing11\"},{\"uuid\":\"e8fb5a86-6f25-474d-bfc6-11cdbdadadd6\",\"name\":\"Alcoholvergunning
+        aanvragen\",\"internalName\":\"\",\"slug\":\"alcoholvergunning-aanvragen\"},{\"uuid\":\"f92a2dec-38bc-4ff0-be96-c1707598d82c\",\"name\":\"Adres\",\"internalName\":\"Adres\",\"slug\":\"adres\"},{\"uuid\":\"1e280028-3ae9-4fb7-8fae-5355dc55650b\",\"name\":\"Machtiging
+        telefonie aanvragen\",\"internalName\":\"DV_ATM_Thomas\",\"slug\":\"machtiging-telefonie-aanvragen\"},{\"uuid\":\"0d1d4f46-4887-4f13-a710-61eaa0601d17\",\"name\":\"testing11
+        (kopie)\",\"internalName\":\"\",\"slug\":\"testing11-kopie-2\"},{\"uuid\":\"7ae94552-7648-4886-a368-68b9e9114102\",\"name\":\"Machtiging
+        telefonie aanvragen\",\"internalName\":\"DV_ATM_Thomas\",\"slug\":\"machtiging-telefonie-aanvragen-4dc9cd\"},{\"uuid\":\"20c35740-c06d-45cc-b389-d80744b3d8fc\",\"name\":\"kaartform\",\"internalName\":\"\",\"slug\":\"kaartform\"},{\"uuid\":\"6f0a3cca-e9ea-4dfe-8424-8e6da2ff8922\",\"name\":\"Vraag
+        of klacht\",\"internalName\":\"\",\"slug\":\"voorbeeld-vraag-of-klacht-bd39ec\"},{\"uuid\":\"4ac1774d-dd6b-4eed-9506-367ba9698a8f\",\"name\":\"Wijzigingsformulier
+        Kinderopvang (KO)\",\"internalName\":\"\",\"slug\":\"wijzigingsformulier-kinderopvang-ko-a00ced\"},{\"uuid\":\"1432a76c-0191-4684-8909-aec6a5c459b1\",\"name\":\"Wijzigingsformulier
+        Kinderopvang (KO) (kopie)\",\"internalName\":\"\",\"slug\":\"wijzigingsformulier-kinderopvang-ko-a00ced-kopie\"},{\"uuid\":\"6621c65d-8cf3-4c38-9d01-c242718f05b3\",\"name\":\"Hier
+        Formulieronderwerp AD/TEL/GEB\",\"internalName\":\"DIR_FOR AD/TEL/GEB\",\"slug\":\"voluit-geschreven-naam-van-formulier-kopie-3\"},{\"uuid\":\"89298aba-cfe3-4bfb-9087-554eb439d790\",\"name\":\"Leerlingenvervoer\",\"internalName\":\"\",\"slug\":\"leerlingenvervoer-2\"},{\"uuid\":\"8059d13f-78c2-4faf-93a5-e6bab874193f\",\"name\":\"testsjoerd\",\"internalName\":\"\",\"slug\":\"testsjoerd\"},{\"uuid\":\"f2f9a602-febf-4b51-9dd5-220b10e76f94\",\"name\":\"Test
+        Inloggen DigiD\",\"internalName\":\"\",\"slug\":\"test-inloggen-digid\"},{\"uuid\":\"d21c6c30-5b86-438e-9f1c-cce01650369a\",\"name\":\"testvenrayissuevariabelen\",\"internalName\":\"\",\"slug\":\"testvenrayissuevariabelen\"},{\"uuid\":\"9c9de4c4-2481-4f5f-9a9f-2df890b057b2\",\"name\":\"Maykin
+        Test - Payment plugin: Ingenico Ogone\",\"internalName\":\"foobar\",\"slug\":\"maykin-test\"},{\"uuid\":\"b9725061-5af0-4f66-9979-49ce461b8421\",\"name\":\"Vraag
+        of klacht\",\"internalName\":\"WMEBV en SDG ding\",\"slug\":\"vraag-of-klacht-wmebv-sdg\"},{\"uuid\":\"29ecc4b3-b765-42eb-8d2a-b46ed63e2913\",\"name\":\"Handtekening\",\"internalName\":\"\",\"slug\":\"handtekening\"},{\"uuid\":\"ed680633-74b3-4f3d-8728-9fef6eebc8cf\",\"name\":\"Issue
+        3402 - email problems\",\"internalName\":\"\",\"slug\":\"issue-3402-email-problems\"},{\"uuid\":\"2febbe8b-0622-43b1-9747-a76e8baecfae\",\"name\":\"langeteksten\",\"internalName\":\"\",\"slug\":\"langeteksten\"},{\"uuid\":\"955dad5e-bbb1-4d91-bf9f-c2bec3cc75ab\",\"name\":\"Toestemming
+        voor parkeren aanvragen\",\"internalName\":\"\",\"slug\":\"ontheffing-parkeerverbod-parkeerregels\"},{\"uuid\":\"ced288c7-9082-4160-85c6-ed12dd6decd3\",\"name\":\"Aanvraagformulier
+        Ooievaarspas\",\"internalName\":\"Ooievaarspas\",\"slug\":\"aanvraag-formulier-ooievaarspas\"},{\"uuid\":\"35bf6ec4-8061-4e5c-88db-791e906685bc\",\"name\":\"asdasdzxczxczxccasasdas\",\"internalName\":\"\",\"slug\":\"zxcczcasdasdzxczxczxccasasdas-2d6a38\"},{\"uuid\":\"f0333e72-0959-49ab-8b01-5943ab82b6db\",\"name\":\"Hulp
+        of ondersteuning aanvragen (kopie)\",\"internalName\":\"Hulp of ondersteuning
+        aanvragen (Let op: unieke danktekst en mail) (kopie)\",\"slug\":\"sociale-dienstverlening-a0fc9c-kopie\"},{\"uuid\":\"12d33161-f8d5-4797-9226-54618e58eb79\",\"name\":\"Silvia
+        Test Old co-sign\",\"internalName\":\"\",\"slug\":\"silvia-test-old-co-sign\"},{\"uuid\":\"e02c0b46-169a-4c6e-913b-2d60b9b0bc10\",\"name\":\"Afwijking
+        BAG-registratie melden\",\"internalName\":\"SB_BAG\",\"slug\":\"afwijking-bag-registratie-melden\"},{\"uuid\":\"0047655c-69c7-4170-bc6d-5af884065fda\",\"name\":\"Melding
+        voornemen geregistreerd partnerschap\",\"internalName\":\"\",\"slug\":\"melding-voornemen-geregistreerd-partnerschap\"},{\"uuid\":\"dbb284fe-c07b-4f0f-9d6c-2accf12b25ca\",\"name\":\"Schuldhulpverlening\",\"internalName\":\"\",\"slug\":\"schuldhulpverlening\"},{\"uuid\":\"c05fec58-c17c-4a0a-95e7-9905fad7a86e\",\"name\":\"dynamische
+        waarde\",\"internalName\":\"\",\"slug\":\"tetststs-7fbbf2\"},{\"uuid\":\"d821a20a-a25e-4146-8772-16a268ef0bce\",\"name\":\"Tijdelijke
+        container melden\",\"internalName\":\"\",\"slug\":\"tijdelijke-container-melden-2\"},{\"uuid\":\"587757f2-6b42-460e-91a7-63594625ce80\",\"name\":\"Tooltip\",\"internalName\":\"\",\"slug\":\"tooltip\"},{\"uuid\":\"12e3d956-6b13-4866-a7d0-fa57650ef4de\",\"name\":\"Marcel-KvK\",\"internalName\":\"Marcel
+        KvK\",\"slug\":\"marcel-kvk\"},{\"uuid\":\"b9ef5585-9963-40f0-8ce2-b6f11db10a58\",\"name\":\"rxmissiontest\",\"internalName\":\"\",\"slug\":\"rxmissiontest\"},{\"uuid\":\"8c21d4fc-3573-4a88-9d76-4a2a3c433eec\",\"name\":\"Afspraak\",\"internalName\":\"\",\"slug\":\"afspraak\"},{\"uuid\":\"5f61f010-7ef0-4dc0-8057-a4b151e0724c\",\"name\":\"Adres
+        demo\",\"internalName\":\"\",\"slug\":\"voorbeeld-adres-demo\"},{\"uuid\":\"b6df4c08-924e-4e7b-a8dd-26823dc4bb40\",\"name\":\"dynamische
+        waarde\",\"internalName\":\"\",\"slug\":\"tetststs\"},{\"uuid\":\"cd7710b3-23ec-46d1-b03b-107d183a9dd1\",\"name\":\"Basisformulier
+        met DigiD en eHerkenning\",\"internalName\":\"\",\"slug\":\"basisformulieren-met-digid-en-eherkenning\"},{\"uuid\":\"8b41e48d-3ddb-471c-9f06-39ddb79841e4\",\"name\":\"Resumption
+        assumption\",\"internalName\":\"\",\"slug\":\"resumption-assumption\"},{\"uuid\":\"eea51a31-9d3a-4b0f-97d7-50561a75d5f5\",\"name\":\"tescsv
+        voor HHgroepen (kopie) (kopie)\",\"internalName\":\"\",\"slug\":\"tescsv-voor-hhgroepen-copy-copy\"},{\"uuid\":\"d9eaadf4-8653-42d7-b787-364daeedd781\",\"name\":\"Eenmalige
+        energietoeslag\",\"internalName\":\"\",\"slug\":\"eenmalige-energietoeslag-aanvragen\"},{\"uuid\":\"beb7d783-c499-4baf-a45e-eb28be810f10\",\"name\":\"Hulp
+        of ondersteuning aanvragen (door Contactcenter ingevuld)\",\"internalName\":\"Hulp
+        of ondersteuning aanvragen (door Contactcenter ingevuld: Unieke danktekst
+        en mail)\",\"slug\":\"sociale-dienstverlening-copy\"},{\"uuid\":\"654eccde-7122-4257-97de-388bad02a3d4\",\"name\":\"Vergunningaanvraag
+        standplaats\",\"internalName\":\"\",\"slug\":\"vergunningaanvraag-standplaats\"},{\"uuid\":\"fa54bc1c-67b5-424d-ad19-1849b4eb3f4b\",\"name\":\"Test
+        file upload\",\"internalName\":\"\",\"slug\":\"test-file-upload\"},{\"uuid\":\"b25314c4-0170-4e24-b3c0-5bfda93808d6\",\"name\":\"timeout
+        test (kopie)\",\"internalName\":\"\",\"slug\":\"timeout-test-copy\"},{\"uuid\":\"ac4e4bf4-c244-4129-9b70-bb89626bbf0a\",\"name\":\"Test
+        issue 2510\",\"internalName\":\"\",\"slug\":\"test-issue-2510\"},{\"uuid\":\"12f19872-13e8-4523-81c2-42e24bcd866c\",\"name\":\"date
+        translations\",\"internalName\":\"\",\"slug\":\"date-translations\"},{\"uuid\":\"1896161a-61f4-4409-b9d6-2a4b40e0eadd\",\"name\":\"Radio\",\"internalName\":\"\",\"slug\":\"radio\"},{\"uuid\":\"177d9581-9f90-457b-b70f-adeb7cea5b36\",\"name\":\"Hulp
+        of ondersteuning aanvragen (door Contactcenter ingevuld)\",\"internalName\":\"Hulp
+        of ondersteuning aanvragen (door Contactcenter ingevuld: Unieke danktekst
+        en mail)\",\"slug\":\"sociale-dienstverlening-copy-6d3e0d\"},{\"uuid\":\"582ffeac-8159-4a59-a979-4bf0f7484b03\",\"name\":\"Maykin
+        Test - Appointment plugin: JCC (Horst a/d Maas)\",\"internalName\":\"\",\"slug\":\"test-afspraken-82a7de-ee8ddb\"},{\"uuid\":\"14da3266-c1e4-499a-8b72-9f2c6675b89e\",\"name\":\"co-sign
+        testform\",\"internalName\":\"\",\"slug\":\"co-sign-testform\"},{\"uuid\":\"a9cf21c8-e524-459d-aec3-be96a963a82f\",\"name\":\"Movies\",\"internalName\":\"\",\"slug\":\"movies\"},{\"uuid\":\"92401b6d-d639-4dfd-aaca-ba03d8cd9e24\",\"name\":\"testdragbreakinglogic\",\"internalName\":\"\",\"slug\":\"testdragbreakinglogic\"},{\"uuid\":\"917d0d71-cb6a-4130-b6a4-191d81b58dc7\",\"name\":\"Issue
+        3169 - Check template\",\"internalName\":\"\",\"slug\":\"issue-3169-check-template\"},{\"uuid\":\"bd116ce9-9812-486e-9401-2b65647746da\",\"name\":\"Test
+        eIDAS (wel met eIDAS aan)\",\"internalName\":\"\",\"slug\":\"test-eidas-kopie\"},{\"uuid\":\"5c801d72-8223-4acb-b059-d63fb8aa7fb0\",\"name\":\"testform\xAD19882123123123123123123123123\",\"internalName\":\"\",\"slug\":\"annoyingerrors\"},{\"uuid\":\"5145da2b-bbe7-40fd-abee-93c9cabf7ed4\",\"name\":\"testerror831\",\"internalName\":\"\",\"slug\":\"testerror\"},{\"uuid\":\"0c13758c-588b-432e-8030-71f715e6c734\",\"name\":\"3128
+        hidden field\",\"internalName\":\"\",\"slug\":\"3128-hidden-field\"},{\"uuid\":\"a00d76f9-c574-4fcc-ae42-a650c14730d1\",\"name\":\"Testrapport\",\"internalName\":\"Testrapport
+        Open Formulieren\",\"slug\":\"testrapport\"},{\"uuid\":\"aaf338fd-c318-45c8-ad59-2b5f4a4426cc\",\"name\":\"Maykin
+        Test - Prefill plugin: KvK Zoeken\",\"internalName\":\"\",\"slug\":\"test-kvk\"},{\"uuid\":\"7932d9ca-ea15-437a-9da5-efd3ff4cff99\",\"name\":\"Hulp
+        of ondersteuning aanvragen\",\"internalName\":\"Hulp of ondersteuning aanvragen
+        (Let op: unieke danktekst en mail)\",\"slug\":\"sociale-dienstverlening\"},{\"uuid\":\"f8a2fe11-6ab7-4454-91be-541261d3ba94\",\"name\":\"Voorbeeld
+        Stratenlijst\",\"internalName\":\"Voorbeeld Stratenlijst\",\"slug\":\"stratenlijst\"},{\"uuid\":\"76e2d10a-570f-4f80-9137-7309af438bc5\",\"name\":\"Test
+        form objects API\",\"internalName\":\"\",\"slug\":\"test-form-objects-api\"},{\"uuid\":\"8d405521-920e-4d77-8608-dd2f5aa87467\",\"name\":\"Zynyo
+        ondertekenen\",\"internalName\":\"\",\"slug\":\"zynyo-ondertekenen\"},{\"uuid\":\"0b04848d-4514-423b-a524-2cdcfce07b31\",\"name\":\"Aanvraag
+        verhuurvergunning opkoopbescherming\",\"internalName\":\"\",\"slug\":\"aanvraag-verhuurvergunning-opkoopbescherming\"},{\"uuid\":\"0f90d260-c29e-49e8-bc88-80a154776c5e\",\"name\":\"zonder
+        validatie issues\",\"internalName\":\"\",\"slug\":\"gen0x4-62ff95\"},{\"uuid\":\"0bda4360-1a49-4127-843f-28c1de022e24\",\"name\":\"Test
+        eIDAS\",\"internalName\":\"\",\"slug\":\"test-eidas\"},{\"uuid\":\"594f0aed-e958-49f1-a0f7-df163a9ce185\",\"name\":\"Wmo-melding
+        doen\",\"internalName\":\"\",\"slug\":\"wmo-melding-doen\"},{\"uuid\":\"166789eb-93ed-4807-bc1b-b89b4fc055f5\",\"name\":\"Klacht
+        indienen\",\"internalName\":\"\",\"slug\":\"klacht-indienen-acd520\"},{\"uuid\":\"e1a6e2d4-73de-425f-b365-cd8b4eeec38c\",\"name\":\"Testing
+        issue 3378\",\"internalName\":\"\",\"slug\":\"testing-issue\"},{\"uuid\":\"eb6fbd66-059d-4a18-a710-69d66b24913c\",\"name\":\"co-sign
+        220\",\"internalName\":\"\",\"slug\":\"co-sign-220\"},{\"uuid\":\"2ae3f9db-11a3-42ff-9ab8-71bba5098ae8\",\"name\":\"Hulp
+        of ondersteuning aanvragen\",\"internalName\":\"Hulp of ondersteuning aanvragen
+        (Let op: unieke danktekst en mail)\",\"slug\":\"sociale-dienstverlening-a0fc9c\"},{\"uuid\":\"40421acb-e288-41e7-9d50-2bed5796e983\",\"name\":\"Aanvraag
+        Minimaregelingen\",\"internalName\":\"\",\"slug\":\"aanvraag-minimaregelingen\"},{\"uuid\":\"9a2d7d33-3e5a-4ba8-a3c6-11038fa7b4cc\",\"name\":\"Speedpedelec,
+        ontheffing aanvragen\",\"internalName\":\"\",\"slug\":\"speedpedelec-ontheffing-aanvragen\"},{\"uuid\":\"149e8977-246e-46e8-b69f-947dc688d96f\",\"name\":\"Werkzaamheden
+        haven Scheveningen melden\",\"internalName\":\"Werkzaamheden haven Scheveningen
+        melden\",\"slug\":\"werkzaamheden-haven-scheveningen-melden-89a297-7cfcc4\"},{\"uuid\":\"6a3c7499-08e1-48cc-919c-f81ed8a6d481\",\"name\":\"Issue
+        3432 - Removing variables used in logic\",\"internalName\":\"\",\"slug\":\"issue-3432-removing-variables-used-in-logic\"},{\"uuid\":\"32dab0d9-4a88-465a-91bf-f87b237ab229\",\"name\":\"Vergunningaanvraag
+        standplaats\",\"internalName\":\"\",\"slug\":\"vergunningaanvraag-standplaats-e3eeaf\"},{\"uuid\":\"f89bd2be-9ba0-4be3-aaba-e18a7d11745c\",\"name\":\"Issue
+        4276 (duplicate FDs)\",\"internalName\":\"\",\"slug\":\"issue-4276-duplicate-fds\"},{\"uuid\":\"665be336-2625-4fe9-b4a1-bcd57a1dc637\",\"name\":\"Uw
+        gegevens compleet\",\"internalName\":\"\",\"slug\":\"uw-gegevens-compleet\"},{\"uuid\":\"71774d4e-a2cd-4878-bae0-5667c78bf649\",\"name\":\"Aangifte
+        overlijden\",\"internalName\":\"\",\"slug\":\"aangifte-overlijden\"},{\"uuid\":\"897eb99a-8e0e-480e-97c6-e93b115a15fe\",\"name\":\"Melden
+        vermissing reisdocumenten\",\"internalName\":\"DV_MVR\",\"slug\":\"melden-vermissing-reisdocumenten\"},{\"uuid\":\"42ed8be5-09ec-462e-8726-365dedf5d073\",\"name\":\"Aanmelden
+        afscheid burgemeester\",\"internalName\":\"Afscheid burgemeester aanmelden
+        [Mail]\",\"slug\":\"aanmelden-afscheid-burgemeester-ebbd6a\"},{\"uuid\":\"2a296737-d5fd-4c58-9c19-87958f896a8b\",\"name\":\"Aanmelden
+        inspreken commissievergadering\",\"internalName\":\"Aanmelden inspreken commissievergadering\",\"slug\":\"aanmelden-inspreken-commissievergadering\"},{\"uuid\":\"1317e9d8-0c0d-4591-8bc4-d9670c96cdcd\",\"name\":\"DMN
+        demo 15 mei\",\"internalName\":\"\",\"slug\":\"dmn-demo-15-mei\"},{\"uuid\":\"21e603cb-479c-4f4d-b26f-b6f84dcf2c3e\",\"name\":\"i
+        formed you heard likes\",\"internalName\":\"\",\"slug\":\"i-formed-the-you-heard-like\"},{\"uuid\":\"84f915dd-32f2-4d89-afc7-183e6c8c97c6\",\"name\":\"Standplaats
+        aanvragen\",\"internalName\":\"asdasdasd\",\"slug\":\"standplaatsvergunning\"},{\"uuid\":\"46044b7e-1128-4a20-9080-8c4188fe573d\",\"name\":\"Testing
+        issue 3835\",\"internalName\":\"\",\"slug\":\"testing-issue-3835\"},{\"uuid\":\"62713085-8849-4762-b648-2af3522ae84b\",\"name\":\"Test
+        Inloggen DigiD with OIDC\",\"internalName\":\"\",\"slug\":\"test-inloggen-digid-kopie\"},{\"uuid\":\"2820e4ef-86e5-4749-b3ab-fc12704671fc\",\"name\":\"Testing
+        issue 3671\",\"internalName\":\"\",\"slug\":\"issue-3671\"},{\"uuid\":\"900ab31b-80b1-468d-87c5-4fb2f9d2adc6\",\"name\":\"testprematurevalidation\",\"internalName\":\"\",\"slug\":\"testprematurevalidation\"},{\"uuid\":\"52450057-f8f7-4857-929e-2a0ac90278fe\",\"name\":\"Issue
+        466 - validation errors positioning\",\"internalName\":\"\",\"slug\":\"issue-466-validation-errors-positioning\"},{\"uuid\":\"00bd7222-3017-45dc-8db7-24894aff2a72\",\"name\":\"Iets
+        melden, met of zonder Digid\",\"internalName\":\"\",\"slug\":\"kaartenmagie\"},{\"uuid\":\"1811ef9a-70a0-40c1-adef-10a89a3e22cf\",\"name\":\"Aanmelden
+        afscheid burgemeester\",\"internalName\":\"Afscheid burgemeester aanmelden
+        [Mail]\",\"slug\":\"aanmelden-afscheid-burgemeester-0b3f92\"},{\"uuid\":\"a2a096fe-2c4d-4eed-8f1d-466e39e45177\",\"name\":\"Pollerontheffing\",\"internalName\":\"\",\"slug\":\"pollerontheffing\"},{\"uuid\":\"18fb4963-3c1d-48f0-930d-961defdd468b\",\"name\":\"uploadbug\",\"internalName\":\"\",\"slug\":\"uploadbug\"},{\"uuid\":\"d0b45bd8-0440-435d-85aa-f27455f8b06b\",\"name\":\"Toegankelijkheid
+        titel\",\"internalName\":\"\",\"slug\":\"toegankelijkheid\"},{\"uuid\":\"ff457ef3-5dbc-4709-9124-cb503eaaeea1\",\"name\":\"Optional
+        number\",\"internalName\":\"\",\"slug\":\"optional-number\"},{\"uuid\":\"06665959-093a-41de-9c47-d23060cab36b\",\"name\":\"Test
+        telefoonnummer\",\"internalName\":\"\",\"slug\":\"test-telefoonnummer\"},{\"uuid\":\"3e8bfec2-c42a-45a2-9a43-4405c1c7c9a5\",\"name\":\"familietest\",\"internalName\":\"\",\"slug\":\"familie\"},{\"uuid\":\"ddbd318c-f485-48fa-a64c-306602985331\",\"name\":\"Issue
+        4052 - Payment emails problems\",\"internalName\":\"\",\"slug\":\"issue-4052-payment-emails-problems\"},{\"uuid\":\"8736197a-7590-4e8b-9fe5-18feccb84ecc\",\"name\":\"Test
+        mede ondertekenen\",\"internalName\":\"\",\"slug\":\"test-mede-ondertekenen\"},{\"uuid\":\"5ea631ed-4668-40b9-9bc3-f01e49df6122\",\"name\":\"2.6.0\",\"internalName\":\"\",\"slug\":\"260\"},{\"uuid\":\"86684255-c5ac-49f1-8ca9-4cceb890f61b\",\"name\":\"Testing
+        ZGW API settings\",\"internalName\":\"\",\"slug\":\"testing-zgw-api-settings\"},{\"uuid\":\"c48b3864-d7ff-402a-83f3-46bce2e32748\",\"name\":\"Inkomstenformulier\",\"internalName\":\"RSD0003
+        Inkomstenformulier\",\"slug\":\"inkomstenformulier-50daac\"},{\"uuid\":\"ef385426-078e-46de-859c-5605db0f69d7\",\"name\":\"Payment
+        flow\",\"internalName\":\"\",\"slug\":\"payment-flow\"},{\"uuid\":\"bdda71b3-d3a8-4685-8fd1-0d2cdebd1a30\",\"name\":\"Evenement
+        organiseren\",\"internalName\":\"Evenement organiseren - ORG [ZDS-Logic]-1120\",\"slug\":\"evenement-organiseren\"},{\"uuid\":\"db0009c6-53e1-45b0-9365-323f0311afa4\",\"name\":\"Test\",\"internalName\":\"TEST\",\"slug\":\"test-47e3ea\"},{\"uuid\":\"b471e13c-3c07-42bc-9d58-5ed3878dd98b\",\"name\":\"Aanmelden
+        inspreken commissievergadering\",\"internalName\":\"Aanmelden inspreken commissievergadering\",\"slug\":\"aanmelden-inspreken-commissievergadering-8b56ac\"},{\"uuid\":\"88027e67-168a-4d52-b145-897b881cb976\",\"name\":\"Formulier
+        t.b.v. testen mede-ondertekenen\",\"internalName\":\"cosigntestmail\",\"slug\":\"cosigntestmail\"},{\"uuid\":\"728367d4-75dd-4283-9507-ac350e15faa7\",\"name\":\"Onrechtmatig
+        wonen en gebruik van een pand melden\",\"internalName\":\"\",\"slug\":\"onrechtmatig-wonen-en-gebruik-van-een-pand-melden\"},{\"uuid\":\"1a41b731-84c3-45e1-b5bb-5d1664a8ed29\",\"name\":\"ec_test_kvk\",\"internalName\":\"ec_test_kvk\",\"slug\":\"ec_test_kvk\"},{\"uuid\":\"482b13f4-3ddb-468b-b6a4-9a5aa8feaa44\",\"name\":\"Nadeelcompensatie
+        aanvragen\",\"internalName\":\"\",\"slug\":\"nadeelcompensatie-aanvragen\"},{\"uuid\":\"be57ec18-436b-4d0a-9503-1c9c8311c486\",\"name\":\"Herhalende
+        groepen test\",\"internalName\":\"\",\"slug\":\"herhalende-groepen-test\"},{\"uuid\":\"dfd8d534-76ab-4222-ac3c-3fbdc93a7767\",\"name\":\"Analyse
+        design shortcomings\",\"internalName\":\"\",\"slug\":\"analyse-design-shortcomings\"},{\"uuid\":\"7c79f561-c093-47c2-bfe3-e44dfa84ac03\",\"name\":\"Evaluate
+        DMN table (demo)\",\"internalName\":\"\",\"slug\":\"evaluate-dmn-table-copy\"},{\"uuid\":\"ac9a5b7c-2e33-48d7-a84e-55129f84eabd\",\"name\":\"Formulier
+        voorbeeld\",\"internalName\":\"\",\"slug\":\"formulier-voorbeeld\"},{\"uuid\":\"efbc4c57-2bac-4e90-9fe2-b0ec856a7c32\",\"name\":\"Evaluate
+        DMN table\",\"internalName\":\"\",\"slug\":\"evaluate-dmn-table\"},{\"uuid\":\"1bf66e28-020b-4650-92a2-b58613c977a0\",\"name\":\"testradiovalue\",\"internalName\":\"\",\"slug\":\"testradiovalue\"},{\"uuid\":\"187f86b3-4493-40a5-b3f2-24af6904c3e4\",\"name\":\"pdfellende\",\"internalName\":\"\",\"slug\":\"pdfellende\"},{\"uuid\":\"7b0d570c-2b80-4bd0-9185-88a9fa3afaec\",\"name\":\"exportnobuenno\",\"internalName\":\"\",\"slug\":\"exportnobuenno\"},{\"uuid\":\"2c7d6d7d-317f-4ef8-a2d4-6b08777a7fca\",\"name\":\"Exploitatievergunning
+        aanvragen\",\"internalName\":\"\",\"slug\":\"exploitatievergunning-aanvragen\"},{\"uuid\":\"22dc1b5d-0da6-406a-8d73-a06e587009f4\",\"name\":\"Aanmeldformulier
+        hulp gedupeerden\",\"internalName\":\"\",\"slug\":\"aanmeldformulier-hulp-gedupeerden\"},{\"uuid\":\"95282aa1-35b4-4c5c-b1fb-4fe7fcfcb600\",\"name\":\"Bouwtekeningen
+        opvragen\",\"internalName\":\"Bouwtekeningen opvragen\",\"slug\":\"bouwtekeningen-opvragen\"},{\"uuid\":\"39874407-1525-45ff-b1ff-18c7b6ab10a6\",\"name\":\"Test
+        berekeningen\",\"internalName\":\"\",\"slug\":\"test-berekening-percentage\"},{\"uuid\":\"eb5f00d7-8c78-4105-bcb1-3d1af8501c94\",\"name\":\"Test
+        2.5.0 release - PDF testing\",\"internalName\":\"\",\"slug\":\"test-250-release-pdf-testing\"},{\"uuid\":\"7a919814-5d06-4009-9eaf-e973d425b6d4\",\"name\":\"Investigating
+        3777\",\"internalName\":\"\",\"slug\":\"investigating-3777\"},{\"uuid\":\"73d85f44-40c6-404a-ab96-087b6f62cd4a\",\"name\":\"ec_test_kvk\",\"internalName\":\"ec_test_kvk\",\"slug\":\"ec_test_kvk-f1c9b8\"},{\"uuid\":\"ff4119af-40e9-40c8-88d2-73abc2cfd677\",\"name\":\"Yer
+        a wizard Harry! (style tag issues)\",\"internalName\":\"\",\"slug\":\"style\"},{\"uuid\":\"6f5b554b-969c-48ab-a737-4861407fa661\",\"name\":\"Testing
+        retrying register submission\",\"internalName\":\"\",\"slug\":\"testing\"},{\"uuid\":\"ac65212a-247e-40b0-a342-77eb76bdc881\",\"name\":\"Nadeelcompensatie
+        aanvragen (kopie)\",\"internalName\":\"\",\"slug\":\"nadeelcompensatie-aanvragen-copy\"},{\"uuid\":\"07cc876d-a846-4240-866a-6ab8848db0ab\",\"name\":\"3922\",\"internalName\":\"\",\"slug\":\"3922\"},{\"uuid\":\"95bfa048-a9ad-4d86-8100-d219bd45b132\",\"name\":\"eulanden\",\"internalName\":\"\",\"slug\":\"eulanden\"},{\"uuid\":\"8234a4ac-41ea-424b-9b60-7d3f9c57aed4\",\"name\":\"Taiga
+        Issue 88 - content component\",\"internalName\":\"\",\"slug\":\"taiga-issue-88-content-component\"},{\"uuid\":\"c82eadac-3fe3-44cd-a6b3-d2da72fec9d6\",\"name\":\"Aanvraag
+        nieuwe toegangspas ondergrondse container\",\"internalName\":\"Aanvraag vervangende
+        toegangspas ondergrondse container\",\"slug\":\"aanvraag-vervangende-toegangspas-ondergrondse-container\"},{\"uuid\":\"b051e053-e1f3-474a-af1d-b12699c231fe\",\"name\":\"Aankoopverzoek
+        gemeentegrond\",\"internalName\":\"\",\"slug\":\"gebruik-gemeentegrond\"},{\"uuid\":\"c7d3d147-6eb2-4a35-a29e-766ce32997e2\",\"name\":\"Melden
+        vermissing reisdocumenten\",\"internalName\":\"DV_MVR\",\"slug\":\"melden-vermissing-reisdocumenten-72e56a\"},{\"uuid\":\"3a0d2974-2f99-406b-af97-dc7f7132aa81\",\"name\":\"tescsv
+        voor HHgroepen\",\"internalName\":\"\",\"slug\":\"tescsv-voor-hhgroepen\"},{\"uuid\":\"b6a06ad1-37e7-49f9-b8c7-7203b08047fb\",\"name\":\"Testing
+        payment form with Ogone\",\"internalName\":\"\",\"slug\":\"testing-payment-form-with-ogone\"},{\"uuid\":\"e5c732f1-1cf3-491e-9172-8959a56e9d17\",\"name\":\"HaalCentraal\",\"internalName\":\"HaalCentraal\",\"slug\":\"haalcentraal\"},{\"uuid\":\"3d36eacf-84ee-4e40-89dc-df0d592c8b4a\",\"name\":\"Voorbeeld
+        Berekeningen\",\"internalName\":\"Voorbeeld Berekeningen [Logic]\",\"slug\":\"voorbeeld-berekeningen\"},{\"uuid\":\"273b241e-c7c9-4300-b98b-4077784a93c6\",\"name\":\"Testing
+        payment and cosign\",\"internalName\":\"\",\"slug\":\"testing-payment-and-cosign\"},{\"uuid\":\"b053c9b2-f44e-4134-be13-62aa1783fc37\",\"name\":\"PDF
+        crash with unicode chars: \U0001D200?\",\"internalName\":\"\",\"slug\":\"pdf-crash-with-unicode-chars\"},{\"uuid\":\"95eab679-9791-4da3-87de-5d70ea77200f\",\"name\":\"stommedatunms\",\"internalName\":\"\",\"slug\":\"stommedatunms\"},{\"uuid\":\"e81f5f55-0d7d-499d-aede-126ddcb03776\",\"name\":\"Testing
+        margin-padding (form definition)\",\"internalName\":\"\",\"slug\":\"testing-margin-padding-in\"},{\"uuid\":\"4bc90c74-0e19-4b26-bc0f-9e4ddd4bf7d8\",\"name\":\"2.7
+        manual testing\",\"internalName\":\"2.7 tests, Sergei\",\"slug\":\"27-manual-testing\"},{\"uuid\":\"0da87d79-4ac1-4914-866a-5317f950b61a\",\"name\":\"Vraag
+        of klacht (kopie)\",\"internalName\":\"\",\"slug\":\"voorbeeld-vraag-of-klacht-bd39ec-kopie\"},{\"uuid\":\"53fc7427-df08-412e-a717-ae4542ad6241\",\"name\":\"Testing
+        form without payment\",\"internalName\":\"\",\"slug\":\"testing-form-without-payment\"},{\"uuid\":\"34ddfbfa-2864-4591-9079-986c9f78a199\",\"name\":\"Testing
+        issue 3797 (repeating groups)\",\"internalName\":\"\",\"slug\":\"testing-3787\"},{\"uuid\":\"a576db2c-c1b8-422b-beed-50758d21b202\",\"name\":\"Herhalende
+        groep demo\",\"internalName\":\"\",\"slug\":\"herhalende-groep-demo-2f4edc\"},{\"uuid\":\"755f17e9-9454-4df9-83d0-057ea3c2912d\",\"name\":\"Aanvraag
+        subsidie ondersteuning en zorg\",\"internalName\":\"\",\"slug\":\"aanvraag-subsidie-ondersteuning-zorg\"},{\"uuid\":\"f1da5d54-621a-4284-aa14-539324e73489\",\"name\":\"Mini
+        test formulier\",\"internalName\":\"\",\"slug\":\"mini-test-formulier\"},{\"uuid\":\"0cb79f15-3792-44de-bc9c-1750a7234f0d\",\"name\":\"Gezinspagina\",\"internalName\":\"Gezinspagina
+        compleet\",\"slug\":\"gezin-ed65ce\"},{\"uuid\":\"291273f6-310b-4da8-972a-2031519b19a9\",\"name\":\"Payment
+        flow (kopie)\",\"internalName\":\"\",\"slug\":\"payment-flow-kopie\"},{\"uuid\":\"5f3a92f2-ba09-4e1c-b201-3052d963ed83\",\"name\":\"Klacht
+        over de gemeente doorgeven\",\"internalName\":\"\",\"slug\":\"klacht-over-de-gemeente-doorgeven\"},{\"uuid\":\"4f7a220a-95cd-4942-940e-6cada521ade8\",\"name\":\"Aanvraagformulier
+        Financi\xEBle Ondersteuning Ondernemers\",\"internalName\":\"Financiele Ondersteuning
+        Ondernemers\",\"slug\":\"aanvraagformulier-financiele-ondersteuning-ondernemers\"},{\"uuid\":\"0642c938-61b4-458b-b2fe-6730b8b77bcf\",\"name\":\"objectnulls\",\"internalName\":\"\",\"slug\":\"objectnulls\"},{\"uuid\":\"73636125-7859-4418-b7bb-303d3b371a2d\",\"name\":\"4009\",\"internalName\":\"\",\"slug\":\"4009\"},{\"uuid\":\"2b05904d-a4b5-48dd-b86c-c0ea9c118bbb\",\"name\":\"Aanvraag
+        betalingsregeling boete huisvuil\",\"internalName\":\"\",\"slug\":\"aanvraag-betalingsregeling-boete-huisvuil-1cc1f4\"},{\"uuid\":\"d75584db-2913-493d-94f4-b04a5c647cc1\",\"name\":\"Testing
+        issue 3960\",\"internalName\":\"\",\"slug\":\"testing-issue-3960\"},{\"uuid\":\"6dc9e5da-2eee-4af5-a52a-cc0e91e28f08\",\"name\":\"Integriteitsschending
+        melden\",\"internalName\":\"BCO_INT (fixed?)\",\"slug\":\"integriteitsschending-melden-20c9c0\"},{\"uuid\":\"2a97b638-9135-4d4a-948c-6882b39f0f7b\",\"name\":\"Testing
+        appointments\",\"internalName\":\"\",\"slug\":\"testing-appointments\"},{\"uuid\":\"a0f4eba8-08d7-48ea-abfd-bc50d4932b6b\",\"name\":\"Aanvraagformulier
+        Financi\xEBle Ondersteuning Ondernemers (kopie)\",\"internalName\":\"Financiele
+        Ondersteuning Ondernemers (kopie)\",\"slug\":\"aanvraagformulier-financiele-ondersteuning-ondernemers-kopie\"},{\"uuid\":\"4e39d224-6889-4784-b2fc-6eb7db30f254\",\"name\":\"test
+        asterix\",\"internalName\":\"\",\"slug\":\"test-asterix\"},{\"uuid\":\"df569f24-467d-40cb-aad8-8582bae5f604\",\"name\":\"Loonkostensubsidie
+        aanvragen\",\"internalName\":\"\",\"slug\":\"loon-kosten-subsidie\"},{\"uuid\":\"b19ca2db-cbe7-45c7-ae9b-d157005a36d9\",\"name\":\"objectnulls
+        (kopie)\",\"internalName\":\"\",\"slug\":\"objectnulls-kopie\"},{\"uuid\":\"bf1f8a27-ec2d-472c-90b4-cef19ee35010\",\"name\":\"testproductprijs\",\"internalName\":\"\",\"slug\":\"testproductprijs\"},{\"uuid\":\"c9900b71-2cf6-478f-8d19-3d58db1a21f2\",\"name\":\"Principeverzoek\",\"internalName\":\"\",\"slug\":\"principeverzoek-171f3b\"},{\"uuid\":\"6b3e063b-f866-4a26-b8c2-ab232e9f22c7\",\"name\":\"Aanvraag
+        betalingsregeling boete huisvuil broken\",\"internalName\":\"\",\"slug\":\"aanvraag-betalingsregeling-boete-huisvuil-broken\"},{\"uuid\":\"f0371d64-fd87-4b77-9e31-5a724034c4d5\",\"name\":\"Bijzondere
+        bijstand aanvragen\",\"internalName\":\"Hulp of ondersteuning aanvragen Mijn
+        Zwolle\",\"slug\":\"sociale-dienstverlening-mijn-zwolle\"},{\"uuid\":\"813841b9-0572-43ab-a21a-c35fd8916cf4\",\"name\":\"Integriteitsschending
+        melden\",\"internalName\":\"BCO_INT\",\"slug\":\"integriteitsschending-melden-afd59c\"},{\"uuid\":\"10fe80f7-0635-4422-89ad-4c2401c6c6b6\",\"name\":\"Test
+        appointments - Release 2.5.0\",\"internalName\":\"\",\"slug\":\"test-appointments-release-250\"},{\"uuid\":\"5866c1a7-b677-4ef1-b092-0137801fbab8\",\"name\":\"Embedding
+        test\",\"internalName\":\"\",\"slug\":\"embedding-test\"},{\"uuid\":\"a1657670-2ce8-4baa-a006-5aedd3b802f5\",\"name\":\"Melding
+        maken\",\"internalName\":\"Melding maken  (Let op: unieke danktekst en mail)\",\"slug\":\"direct-melden\"},{\"uuid\":\"a46ea7ad-5a4d-48bf-b2a9-409277f0e451\",\"name\":\"Foutgeparkeerde
+        motorvoertuigen melden\",\"internalName\":\"\",\"slug\":\"foutgeparkeerde-motorvoertuigen-melden\"},{\"uuid\":\"7f7090d3-eb96-421f-9480-5d22ffec0f26\",\"name\":\"Integriteitsschending
+        melden\",\"internalName\":\"BCO_INT\",\"slug\":\"integriteitsschending-melden-2db9f3\"},{\"uuid\":\"1a9aa209-a2d0-48a8-af30-cfab20bff313\",\"name\":\"Payment
+        flow (kopie)\",\"internalName\":\"\",\"slug\":\"payment-flow-kopie-2\"},{\"uuid\":\"b9d5f860-bacb-4b33-b91f-fb8fd5bf6561\",\"name\":\"Button
+        styles refactor\",\"internalName\":\"\",\"slug\":\"button-styles-refactor\"},{\"uuid\":\"64b02149-dcb6-4dda-ae7a-b7f815ae2ce7\",\"name\":\"2soortenuploads\",\"internalName\":\"\",\"slug\":\"mockerdemock\"},{\"uuid\":\"9276c2f7-54ec-4a28-b5e5-62dcb5370611\",\"name\":\"Aanvraag
+        leerlingenvervoer\",\"internalName\":\"Leerlingenvervoer\",\"slug\":\"aanvraag-leerlingenvervoer\"},{\"uuid\":\"77bca909-d98f-402c-8d0d-f86074868fd1\",\"name\":\"Aanvraagformulier
+        Financi\xEBle Ondersteuning Ondernemers\",\"internalName\":\"Financiele Ondersteuning
+        Ondernemers\",\"slug\":\"aanvraagformulier-financiele-ondersteuning-ondernemers-2e7096\"},{\"uuid\":\"a8cf5964-ceb9-4f88-9919-541f79eac26e\",\"name\":\"Inkomstenformulier\",\"internalName\":\"RSD0003
+        Inkomstenformulier\",\"slug\":\"inkomstenformulier-858efb\"},{\"uuid\":\"b8c6d755-c365-4bfe-b42d-a8696c6548db\",\"name\":\"Test
+        KvK\",\"internalName\":\"\",\"slug\":\"test-kvk-bla\"},{\"uuid\":\"1127a59f-f4e9-4e60-a000-65138bfbad39\",\"name\":\"Aanvraagformulier
+        Financi\xEBle Ondersteuning Ondernemers (kopie) (kopie)\",\"internalName\":\"Financiele
+        Ondersteuning Ondernemers (kopie) (kopie)\",\"slug\":\"aanvraagformulier-financiele-ondersteuning-ondernemers-kopie-kopie\"},{\"uuid\":\"09d36430-3715-41d7-a36b-9ad313058343\",\"name\":\"Overlijdens
+        aangifte\",\"internalName\":\"\",\"slug\":\"overlijdens_aangifte\"},{\"uuid\":\"404a4c6c-fd47-4f5b-98f7-70eed0a8b698\",\"name\":\"Issue
+        3523\",\"internalName\":\"\",\"slug\":\"issue-3523\"},{\"uuid\":\"7700b3d3-5334-4f1a-9db3-ca2d558841ee\",\"name\":\"Evenementenvergunning
+        aanvragen\",\"internalName\":\"\",\"slug\":\"evenementenvergunning\"},{\"uuid\":\"0f1c7cc1-b466-46a9-b5d8-c81a43755a52\",\"name\":\"voorwaardelijke
+        opmaak in content\",\"internalName\":\"\",\"slug\":\"voorwaardelijke-opmaak-in-content\"},{\"uuid\":\"9d1db647-30b2-49a9-8f97-23adfcad9a06\",\"name\":\"Het
+        Hogeland\",\"internalName\":\"\",\"slug\":\"het-hogeland\"},{\"uuid\":\"4b89d32d-0e42-45c8-970d-ff6ac6d4d765\",\"name\":\"timeout
+        test \U0001F484\",\"internalName\":\"\",\"slug\":\"timeout-test-oud\"},{\"uuid\":\"b0fd82f6-d78f-493a-9d6e-9157de1731b1\",\"name\":\"Rioolaansluiting
+        aanvragen\",\"internalName\":\"\",\"slug\":\"rioolaansluiting-aanvragen-238e7a\"},{\"uuid\":\"ba096284-fc50-4dc2-8186-b2809a70a448\",\"name\":\"bug
+        formulier\",\"internalName\":\"\",\"slug\":\"bug-formulier\"}]}"
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - max-age=0, no-cache, no-store, must-revalidate, private
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Language:
+      - nl
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Wed, 31 Jul 2024 09:12:35 GMT
+      Expires:
+      - Wed, 31 Jul 2024 09:12:35 GMT
+      Permissions-Policy:
+      - accelerometer=(), autoplay=(), camera=(self), gyroscope=(), geolocation=(self),
+        magnetometer=(), microphone=()
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - same-origin
+      - same-origin
+      Set-Cookie:
+      - csrftoken=tCPSyynrD9Zq9noVDDpA3j9eyYTNN8yO; expires=Wed, 30 Jul 2025 09:12:35
+        GMT; Max-Age=31449600; Path=/; SameSite=None; Secure
+      - openforms_sessionid=xfmxg3q65l3mlxd2e4q0o4q04ghj1ko0; expires=Wed, 31 Jul
+        2024 09:17:35 GMT; HttpOnly; Max-Age=300; Path=/; SameSite=None; Secure
+      Strict-Transport-Security:
+      - max-age=63072000
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Cookie, Origin, Accept-Language
+      X-CSRFToken:
+      - m6oAaJTXF3k4VJ8huCVB1mqMYLOWyiR4Fy3iy76e829kUWm2X5a1UvpQmzxzbgfI
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Is-Form-Designer:
+      - 'true'
+      X-Session-Expires-In:
+      - '300'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://open-forms.test.maykin.opengem.nl/api/v2/forms/9c65ab49-2635-4c8d-ac22-aaca67044a6c
+  response:
+    body:
+      string: '{"uuid":"9c65ab49-2635-4c8d-ac22-aaca67044a6c","name":"Open Inwoner
+        ZGW Dev","internalName":"","loginRequired":false,"translationEnabled":false,"registrationBackends":[{"key":"zgw-create-zaak","name":"ZGW
+        API''s","backend":"zgw-create-zaak","options":{"zaaktype":"https://test.openzaak.nl/catalogi/api/v1/zaaktypen/a88c1519-6de5-4db3-8cb6-35c6942938d3","zgwApiGroup":1,"informatieobjecttype":"https://test.openzaak.nl/catalogi/api/v1/informatieobjecttypen/1db73aba-cef4-42ec-bdf0-cd4c7c4f2514"}}],"registrationBackend":"zgw-create-zaak","registrationBackendOptions":{"zaaktype":"https://test.openzaak.nl/catalogi/api/v1/zaaktypen/a88c1519-6de5-4db3-8cb6-35c6942938d3","zgwApiGroup":1,"informatieobjecttype":"https://test.openzaak.nl/catalogi/api/v1/informatieobjecttypen/1db73aba-cef4-42ec-bdf0-cd4c7c4f2514"},"authenticationBackendOptions":{},"loginOptions":[],"autoLoginAuthenticationBackend":"","paymentRequired":false,"paymentBackend":"","paymentBackendOptions":{},"paymentOptions":[],"appointmentOptions":{"isAppointment":false,"supportsMultipleProducts":null},"literals":{"previousText":{"resolved":"Vorige
+        stap","value":""},"beginText":{"resolved":"Formulier starten","value":""},"changeText":{"resolved":"Wijzigen","value":""},"confirmText":{"resolved":"Bevestigen","value":""}},"product":null,"slug":"open-inwoner-zgw-dev","url":"https://open-forms.test.maykin.opengem.nl/api/v2/forms/9c65ab49-2635-4c8d-ac22-aaca67044a6c","category":"https://open-forms.test.maykin.opengem.nl/api/v2/public/categories/5ad402aa-3330-402b-b763-670dbc2d5521","theme":null,"steps":[{"uuid":"7a6e3281-2717-47b4-b5b4-f0fb5d541fcb","slug":"open-inwoner-zgw-dev","formDefinition":"Open
+        Inwoner ZGW Dev","index":0,"literals":{"previousText":{"resolved":"Terug","value":""},"saveText":{"resolved":"Pauzeren","value":""},"nextText":{"resolved":"Volgende","value":""}},"url":"https://open-forms.test.maykin.opengem.nl/api/v2/forms/9c65ab49-2635-4c8d-ac22-aaca67044a6c/steps/7a6e3281-2717-47b4-b5b4-f0fb5d541fcb","isApplicable":true}],"showProgressIndicator":true,"maintenanceMode":false,"active":true,"activateOn":null,"deactivateOn":null,"isDeleted":false,"submissionConfirmationTemplate":"","explanationTemplate":"","submissionAllowed":"yes","suspensionAllowed":true,"askPrivacyConsent":"global_setting","askStatementOfTruth":"global_setting","submissionsRemovalOptions":{"successfulSubmissionsRemovalLimit":null,"successfulSubmissionsRemovalMethod":"","incompleteSubmissionsRemovalLimit":null,"incompleteSubmissionsRemovalMethod":"","erroredSubmissionsRemovalLimit":null,"erroredSubmissionsRemovalMethod":"","allSubmissionsRemovalLimit":null},"confirmationEmailTemplate":{"subject":"","content":"","translations":{"nl":{"subject":"","content":""},"en":{"subject":"","content":""}}},"sendConfirmationEmail":true,"displayMainWebsiteLink":true,"includeConfirmationPageContentInPdf":true,"requiredFieldsWithAsterisk":false,"translations":{"nl":{"name":"Open
+        Inwoner ZGW Dev","submissionConfirmationTemplate":"","beginText":"","previousText":"","changeText":"","confirmText":"","explanationTemplate":""},"en":{"name":"","submissionConfirmationTemplate":"","beginText":"","previousText":"","changeText":"","confirmText":"","explanationTemplate":""}},"resumeLinkLifetime":7,"hideNonApplicableSteps":true,"cosignLoginOptions":[],"cosignLoginInfo":null,"submissionStatementsConfiguration":[{"key":"privacyPolicyAccepted","label":"<p>Ja,
+        ik heb kennis genomen van het <a href=\"https://www.maykinmedia.nl/en/privacy/\"
+        target=\"_blank\" rel=\"noreferrer noopener\">privacybeleid</a>&nbsp;en geef
+        uitdrukkelijk toestemming voor het verwerken van de door mij opgegeven gegevens.</p>","validate":{"required":true},"type":"checkbox"},{"key":"statementOfTruthAccepted","label":"<p>Ik
+        verklaar dat ik deze aanvraag naar waarheid heb ingevuld en geen informatie
+        heb verzwegen.</p>","validate":{"required":false},"type":"checkbox"}],"submissionReportDownloadLinkTitle":"Download
+        een overzicht van de ingestuurde gegevens.","brpPersonenRequestOptions":null}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Cache-Control:
+      - max-age=0, no-cache, no-store, must-revalidate, private
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Language:
+      - nl
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Wed, 31 Jul 2024 09:12:36 GMT
+      Expires:
+      - Wed, 31 Jul 2024 09:12:36 GMT
+      Permissions-Policy:
+      - accelerometer=(), autoplay=(), camera=(self), gyroscope=(), geolocation=(self),
+        magnetometer=(), microphone=()
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - same-origin
+      - same-origin
+      Set-Cookie:
+      - openforms_language=nl; HttpOnly; Path=/; SameSite=None; Secure
+      - csrftoken=6ENIMADKkPck3LIorlTrjJ0B8h543wei; expires=Wed, 30 Jul 2025 09:12:36
+        GMT; Max-Age=31449600; Path=/; SameSite=None; Secure
+      - openforms_sessionid=guym6cuvtdqz7emtykuvee8yusfviq3b; expires=Wed, 31 Jul
+        2024 09:17:36 GMT; HttpOnly; Max-Age=300; Path=/; SameSite=None; Secure
+      Strict-Transport-Security:
+      - max-age=63072000
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      - Cookie, Origin, Accept-Language
+      X-CSRFToken:
+      - mEhOGFMpge2iqYcifHl6m9hp4SpLPnuVi8Umi5fZqT4sjzKwwS4nvI7Q2ZkFIJy3
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Is-Form-Designer:
+      - 'true'
+      X-Session-Expires-In:
+      - '300'
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://open-forms.test.maykin.opengem.nl/api/v2/forms/aaaa-bbbb-cccc-dddd
+  response:
+    body:
+      string: '{"type":"https://open-forms.test.maykin.opengem.nl/fouten/NotFound/","code":"not_found","title":"Niet
+        gevonden.","status":404,"detail":"Niet gevonden.","instance":"urn:uuid:b5638414-d8b9-4c18-9a8d-558e6e344732"}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Cache-Control:
+      - max-age=0, no-cache, no-store, must-revalidate, private
+      Connection:
+      - keep-alive
+      Content-Language:
+      - nl
+      Content-Length:
+      - '211'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Wed, 31 Jul 2024 09:12:36 GMT
+      Expires:
+      - Wed, 31 Jul 2024 09:12:36 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - same-origin
+      Set-Cookie:
+      - csrftoken=oOzYmCIovjGOEHn528qR4rJA0d8Pfg1B; expires=Wed, 30 Jul 2025 09:12:36
+        GMT; Max-Age=31449600; Path=/; SameSite=None; Secure
+      - openforms_sessionid=0xx8zxqp923yfol6vquloriu5td4mq0z; expires=Wed, 31 Jul
+        2024 09:17:36 GMT; HttpOnly; Max-Age=300; Path=/; SameSite=None; Secure
+      Strict-Transport-Security:
+      - max-age=63072000
+      Vary:
+      - Cookie, Origin, Accept-Language
+      X-CSRFToken:
+      - wSyTpCI8IlEHpKtjkcvvrc4WaBykPZH4KwXHB4gm3ualThGecaLcltDm0EwZU5yv
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Is-Form-Designer:
+      - 'true'
+      X-Session-Expires-In:
+      - '300'
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/fixtures/cassettes/invalid.yaml
+++ b/fixtures/cassettes/invalid.yaml
@@ -1,0 +1,126 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://open-forms.test.maykin.opengem.nl/api/v2/public/forms
+  response:
+    body:
+      string: '{"type":"https://open-forms.test.maykin.opengem.nl/fouten/AuthenticationFailed/","code":"authentication_failed","title":"Ongeldige
+        authenticatiegegevens.","status":401,"detail":"Ongeldige token.","instance":"urn:uuid:b3f40157-9442-486c-aaba-037f9342c703"}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - max-age=0, no-cache, no-store, must-revalidate, private
+      Connection:
+      - keep-alive
+      Content-Language:
+      - nl
+      Content-Length:
+      - '255'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Wed, 31 Jul 2024 08:05:44 GMT
+      Expires:
+      - Wed, 31 Jul 2024 08:05:44 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - same-origin
+      Set-Cookie:
+      - csrftoken=rDnuLzLrAUGpIgp2gYxelwj7UGZEqCV6; expires=Wed, 30 Jul 2025 08:05:44
+        GMT; Max-Age=31449600; Path=/; SameSite=None; Secure
+      - openforms_sessionid=8ev8ldwpo3vi2qsnw0l176htbcrcbg54; expires=Wed, 31 Jul
+        2024 08:10:44 GMT; HttpOnly; Max-Age=300; Path=/; SameSite=None; Secure
+      Strict-Transport-Security:
+      - max-age=63072000
+      Vary:
+      - Cookie, Origin, Accept-Language
+      WWW-Authenticate:
+      - Token
+      X-CSRFToken:
+      - 5dZg56rok3RheSgkWWqoIhnpkBNVnweDmGcAGv2FKNnwMYvc2KNsTDwm47CpDYZz
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Session-Expires-In:
+      - '300'
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://open-forms.test.maykin.opengem.nl/api/v2/forms/9c65ab49-2635-4c8d-ac22-aaca67044a6c
+  response:
+    body:
+      string: '{"type":"https://open-forms.test.maykin.opengem.nl/fouten/AuthenticationFailed/","code":"authentication_failed","title":"Ongeldige
+        authenticatiegegevens.","status":401,"detail":"Ongeldige token.","instance":"urn:uuid:d545fdc9-8186-456a-999b-c0c388fe922a"}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Cache-Control:
+      - max-age=0, no-cache, no-store, must-revalidate, private
+      Connection:
+      - keep-alive
+      Content-Language:
+      - nl
+      Content-Length:
+      - '255'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Date:
+      - Wed, 31 Jul 2024 08:05:45 GMT
+      Expires:
+      - Wed, 31 Jul 2024 08:05:45 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - same-origin
+      Set-Cookie:
+      - csrftoken=erCNNjLn8PKuLjVPK1ZDw3a4Rv7PUQS9; expires=Wed, 30 Jul 2025 08:05:45
+        GMT; Max-Age=31449600; Path=/; SameSite=None; Secure
+      - openforms_sessionid=qm2mjv9kxo2xcckzvb0flhy5nt5d3zbz; expires=Wed, 31 Jul
+        2024 08:10:45 GMT; HttpOnly; Max-Age=300; Path=/; SameSite=None; Secure
+      Strict-Transport-Security:
+      - max-age=63072000
+      Vary:
+      - Cookie, Origin, Accept-Language
+      WWW-Authenticate:
+      - Token
+      X-CSRFToken:
+      - SDRW8cYDR5y2Ti1Ihv4D8Uns3RlWJ44eWUjzLlzQPK8murMnRmT6uNnmKciBtKMd
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Session-Expires-In:
+      - '300'
+    status:
+      code: 401
+      message: Unauthorized
+version: 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,14 +33,18 @@ install_requires =
     django-solo
     requests
 tests_require =
-    requests-mock
-    pytest
-    pytest-django
-    tox
-    isort
     black
     flake8
+    isort
+    pytest
+    pytest-django
+    python-decouple
+    pyyaml
+    requests
+    requests-mock
     time-machine
+    tox
+    vcrpy
 
 [options.packages.find]
 include =
@@ -49,14 +53,17 @@ include =
 
 [options.extras_require]
 tests =
-    requests-mock
-    pytest
-    pytest-django
-    tox
-    isort
     black
     flake8
+    isort
+    pytest
+    pytest-django
+    python-decouple
+    pyyaml
+    requests-mock
     time-machine
+    tox
+    vcrpy
 pep8 = flake8
 coverage = pytest-cov
 docs =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+from decouple import config
+
+from openformsclient.client import Client
+
+API_ROOT = config("OFC_API_ROOT", "https://open-forms.test.maykin.opengem.nl/api/v2/")
+API_TOKEN = config("OFC_API_TOKEN", "hush-hush")
+
+
+@pytest.fixture
+def client():
+    return Client(api_root=API_ROOT, api_token=API_TOKEN, client_timeout=2)
+
+
+@pytest.fixture
+def bogus_client():
+    return Client(api_root=API_ROOT, api_token="bogus", client_timeout=2)

--- a/tests/data/forms.py
+++ b/tests/data/forms.py
@@ -1,0 +1,6 @@
+test_form = {
+    "uuid": "9c65ab49-2635-4c8d-ac22-aaca67044a6c",
+    "name": "Open Inwoner ZGW Dev",
+    "internalName": "",
+    "slug": "open-inwoner-zgw-dev",
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,91 +1,73 @@
-from unittest.mock import patch
+from urllib.parse import urljoin
 
-from django.test import TestCase
-
-import requests_mock
+import pytest
+import vcr
 from requests.exceptions import HTTPError
 
 from openformsclient.client import Client
 
+from .data.forms import test_form
 
-@requests_mock.Mocker()
-class ClientTests(TestCase):
-    def setUp(self):
-        self.api_root = "https://example.com/api/v2/"
-        self.api_token = "token"
-        self.client_timeout = 2
-        self.client = Client(self.api_root, self.api_token, self.client_timeout)
+CASSETTE_PATH_FORMS = "fixtures/cassettes/forms.yaml"
+CASSETTE_PATH_INVALID = "fixtures/cassettes/invalid.yaml"
+VCR_DEFAULTS = {
+    "record_mode": "none",  # use new_episodes to record casettes
+    "filter_headers": ["authorization"],
+}
 
-    def test_has_config(self, m):
-        self.assertTrue(self.client.has_config())
-        self.assertFalse(Client("", "", "").has_config())
 
-    def test_is_healthy(self, m):
-        m.head(
-            f"{self.api_root}public/forms",
-            request_headers={"Authorization": f"Token {self.api_token}"},
-        )
+def test_client_has_config(client):
+    bogus_client = Client("", "", "")
 
-        health, msg = self.client.is_healthy()
-        self.assertTrue(health)
-        self.assertEqual(msg, "")
+    assert client.has_config()
+    assert not bogus_client.has_config()
 
-    def test_is_healthy_invalid_response(self, m):
-        m.head(f"{self.api_root}public/forms", status_code=500)  # Doesn't really matter
-        m.get(f"{self.api_root}public/forms", text="Woops")
 
-        health, msg = self.client.is_healthy()
-        self.assertFalse(health)
-        self.assertEqual(msg, "Server did not return a valid response (HTTP 500).")
+@vcr.use_cassette(CASSETTE_PATH_FORMS, **VCR_DEFAULTS)
+def test_client_is_healthy(client):
+    health, msg = client.is_healthy()
+    assert health
+    assert msg == ""
 
-    def test_is_healthy_invalid_token(self, m):
-        m.head(f"{self.api_root}public/forms", status_code=401)
-        m.get(
-            f"{self.api_root}public/forms",
-            json={
-                "type": "https://example.com/fouten/AuthenticationFailed/",
-                "code": "authentication_failed",
-                "title": "Ongeldige authenticatiegegevens.",
-                "status": 401,
-                "detail": "Ongeldige token.",
-                "instance": "urn:uuid:8dddcb04-a412-451a-a7c5-f77d1aef36f5",
-            },
-        )
 
-        health, msg = self.client.is_healthy()
-        self.assertFalse(health)
-        self.assertEqual(msg, "Ongeldige token.")
+@vcr.use_cassette(CASSETTE_PATH_FORMS, **VCR_DEFAULTS)
+def test_get_forms(client):
+    results = client.get_forms()["results"]
 
-    def test_get_forms(self, m):
-        m.get(f"{self.api_root}public/forms", json=[])
+    assert test_form in results
 
-        result = self.client.get_forms()
-        self.assertListEqual(result, [])
 
-    def test_get_forms_with_error(self, m):
-        m.get(f"{self.api_root}public/forms", status_code=401)
+@vcr.use_cassette(CASSETTE_PATH_INVALID, **VCR_DEFAULTS)
+def test_get_forms_unauthorized(bogus_client):
+    url = urljoin(bogus_client.api_root, "public/forms")
+    msg = f"401 Client Error: Unauthorized for url: {url}"
 
-        with self.assertRaises(HTTPError):
-            self.client.get_forms()
+    with pytest.raises(HTTPError, match=msg):
+        bogus_client.get_forms()
 
-    def test_get_form(self, m):
-        m.get(f"{self.api_root}forms/myform", json={})
 
-        result = self.client.get_form("myform")
-        self.assertDictEqual(result, {})
+@vcr.use_cassette(CASSETTE_PATH_FORMS, **VCR_DEFAULTS)
+def test_get_single_form(client):
+    result = client.get_form(uuid_or_slug=test_form["uuid"])
 
-    def test_get_form_with_error(self, m):
-        m.get(f"{self.api_root}forms/myform", status_code=401)
+    assert result["uuid"] == test_form["uuid"]
+    assert result["name"] == test_form["name"]
 
-        with self.assertRaises(HTTPError):
-            self.client.get_form("myform")
 
-    def test_request_uses_configured_timeout(self, m):
-        with patch("openformsclient.client.requests.request") as mock_request:
-            self.client.get_form("myform")
-            mock_request.assert_called_with(
-                "get",
-                "https://example.com/api/v2/forms/myform",
-                headers={"Authorization": "Token token"},
-                timeout=2,
-            )
+@vcr.use_cassette(CASSETTE_PATH_FORMS, **VCR_DEFAULTS)
+def test_get_single_form_not_found(client):
+    bogus_uuid = "aaaa-bbbb-cccc-dddd"
+    url = urljoin(client.api_root, f"forms/{bogus_uuid}")
+    msg = f"404 Client Error: Not Found for url: {url}"
+
+    with pytest.raises(HTTPError, match=msg):
+        client.get_form(uuid_or_slug=bogus_uuid)
+
+
+@vcr.use_cassette(CASSETTE_PATH_INVALID, **VCR_DEFAULTS)
+def test_get_single_form_unauthorized(bogus_client):
+    url = urljoin(bogus_client.api_root, f"forms/{test_form['uuid']}")
+    msg = f"401 Client Error: Unauthorized for url: {url}"
+
+    with pytest.raises(HTTPError, match=msg):
+        bogus_client.get_form(uuid_or_slug=test_form["uuid"])

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311}-django{32}
-    py{39,310,311}-django{40}
+    py{311,312}-django{42}
     isort
     black
     flake8
@@ -10,8 +9,7 @@ skip_missing_interpreters = true
 
 [gh-actions:env]
 DJANGO =
-    3.2: django32
-    4.0: django40
+    4.2: django42
 
 [testenv]
 setenv =
@@ -21,9 +19,7 @@ extras =
     tests
     coverage
 deps =
-  setuptools==71.1.0
-  django32: Django~=3.2.0
-  django40: Django~=4.0.0
+  django42: Django~=4.2.0
 commands =
   py.test tests \
    --junitxml=reports/junit.xml \

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ extras =
     tests
     coverage
 deps =
+  setuptools==71.1.0
   django32: Django~=3.2.0
   django40: Django~=4.0.0
 commands =


### PR DESCRIPTION
- The PR eplaces mocks with VCR casettes and class-based tests with function-based tests for the `test_client` module.
- Support for Python 3.9/3.10 and Django 3.2/4.0 has been removed, support for Python 3.12 and Django 4.2 added (we only need to support Django LTS versions going forward).

